### PR TITLE
Implement typos

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+rust = "latest"
+typos = "latest"

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,0 +1,19 @@
+# See https://github.com/crate-ci/typos/blob/master/docs/reference.md to configure typos
+
+[default]
+extend-ignore-re = [
+    "Caf&eacute;",]
+
+[default.extend-identifiers]
+activeOpps = "activeOpps"
+fo = "fo"
+
+[default.extend-words]
+Anly = "Anly"
+hom = "hom"
+ratatui = "ratatui"
+oint = "oint"
+OT = "OT"
+
+[files]
+extend-exclude = ["crates/gherkin/tests/fixtures/invalid_syntax.md"]

--- a/crates/dg-cli/src/commands/new.rs
+++ b/crates/dg-cli/src/commands/new.rs
@@ -178,7 +178,7 @@ fn warn_future_dates(fields: &[(String, String)], type_def: &TypeDef) {
     }
 }
 
-/// Parse "YYYY-MM-DD..." to epoch days, returns None if unparseable.
+/// Parse "YYYY-MM-DD..." to epoch days, returns None if unparsable.
 fn parse_date_to_epoch_days(s: &str) -> Option<i64> {
     let date_part = if s.len() >= 10 { &s[..10] } else { s };
     let mut parts = date_part.split('-');

--- a/crates/md-db/src/format.rs
+++ b/crates/md-db/src/format.rs
@@ -743,7 +743,7 @@ status: exploring
     }
 
     #[test]
-    fn test_format_file_rejects_unparseable_frontmatter() {
+    fn test_format_file_rejects_unparsable_frontmatter() {
         let dir = std::env::temp_dir().join("dg_fmt_test_bad_yaml");
         std::fs::create_dir_all(&dir).ok();
         let path = dir.join("test.md");
@@ -752,7 +752,7 @@ status: exploring
 
         let schema = test_schema();
         let result = format_file(&path, &schema, false);
-        assert!(result.is_err(), "should error on unparseable YAML");
+        assert!(result.is_err(), "should error on unparsable YAML");
 
         // File must be unchanged
         let content = std::fs::read_to_string(&path).unwrap();


### PR DESCRIPTION
https://github.com/crate-ci/typos

Also start config for https://mise.jdx.dev/. (Oh I see the repo is using direnv; I can remove the .mise.toml if you want)