### PR TITLE
feat: add title to dg-new MCP tool for H1 heading and filename slug

### DIFF
--- a/crates/dg-cli/src/commands/new.rs
+++ b/crates/dg-cli/src/commands/new.rs
@@ -279,7 +279,7 @@ pub fn run(
     let slug = parsed
         .title
         .as_deref()
-        .map(slugify_title)
+        .map(template::slugify)
         .unwrap_or_default();
     let filename = if slug.is_empty() {
         bail!("title is required (used for filename slug)");
@@ -315,19 +315,6 @@ pub fn run(
     }
 
     Ok(())
-}
-
-/// Convert a title to a URL-friendly slug for filenames.
-fn slugify_title(title: &str) -> String {
-    title
-        .to_lowercase()
-        .chars()
-        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
-        .collect::<String>()
-        .split('-')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<_>>()
-        .join("-")
 }
 
 #[cfg(test)]

--- a/crates/dg-mcp/Cargo.toml
+++ b/crates/dg-mcp/Cargo.toml
@@ -14,3 +14,6 @@ md-db = { workspace = true }
 dg-schemas = { path = "../dg-schemas" }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dg-mcp/src/main.rs
+++ b/crates/dg-mcp/src/main.rs
@@ -116,6 +116,7 @@ fn tool_list() -> Value {
                 "type": "object",
                 "properties": {
                     "type":    { "type": "string",  "description": "Document type name" },
+                    "title":   { "type": "string",  "description": "Document title — sets the H1 heading and (under auto_id) the filename slug. Under auto_id a title is REQUIRED and must contain ASCII letters/digits: a missing title, or one that slugifies to nothing (punctuation-/non-ASCII-only), is rejected, matching the CLI. With an explicit `output` path the title is optional and only sets the H1." },
                     "schema":  { "type": "string",  "description": "Path to KDL schema file" },
                     "output":  { "type": "string",  "description": "Output file path" },
                     "dir":     { "type": "string",  "description": "Directory for auto-ID" },

--- a/crates/dg-mcp/src/tools.rs
+++ b/crates/dg-mcp/src/tools.rs
@@ -376,6 +376,22 @@ fn tool_new(args: &Value) -> Result<Value> {
         }
     }
 
+    // `title` feeds the template's "title" override (-> H1) and the auto-id slug.
+    // An explicit `title=` in `fields` wins over the dedicated `title` arg.
+    let title = str_arg(args, "title");
+    if let Some(ref t) = title {
+        if !set_fields.iter().any(|(k, _)| k == "title") {
+            set_fields.push(("title".to_string(), t.clone()));
+        }
+    }
+    // LAST `title=` wins, matching the template's H1 (BTreeMap insert overwrites),
+    // so the slug and the H1 cannot disagree.
+    let effective_title = set_fields
+        .iter()
+        .rev()
+        .find(|(k, _)| k == "title")
+        .map(|(_, v)| v.clone());
+
     let fill = bool_arg(args, "fill");
     let auto_id = bool_arg(args, "auto_id");
 
@@ -384,7 +400,27 @@ fn tool_new(args: &Value) -> Result<Value> {
         let graph = DocGraph::build(PathBuf::from(&dir), &schema)?;
         let next_id = graph.next_id(canonical_type);
         let folder = type_def.folder.as_deref().unwrap_or(".");
-        let filename = format!("{}.md", next_id.to_lowercase());
+        let slug = effective_title
+            .as_deref()
+            .map(template::slugify)
+            .unwrap_or_default();
+        // Match the CLI exactly: under auto_id a title is required and must yield a
+        // non-empty slug. A missing title — or one that slugifies to nothing
+        // (punctuation- or non-ASCII-only) — would produce a bare `{id}.md` that
+        // fails F011, so refuse it loudly instead of writing an invalid document.
+        if slug.is_empty() {
+            match &effective_title {
+                None => anyhow::bail!(
+                    "title is required under auto_id (used for the filename slug); \
+                     pass a `title` with ASCII letters or digits"
+                ),
+                Some(t) => anyhow::bail!(
+                    "title {t:?} produces an empty filename slug (only punctuation or \
+                     non-ASCII characters); provide a title with ASCII letters or digits"
+                ),
+            }
+        }
+        let filename = format!("{}-{slug}.md", next_id.to_lowercase());
         let base = PathBuf::from(&dir);
         if folder != "." && base.ends_with(folder) {
             Some(base.join(filename))
@@ -607,4 +643,92 @@ fn tool_check_code(args: &Value) -> Result<Value> {
         "matches": items,
         "count": items.len(),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    const FIXTURE_SCHEMA: &str = "../../tests/fixtures/schema.kdl";
+
+    fn new_adr(dir: &std::path::Path, args: serde_json::Value) -> Result<Value> {
+        let mut base = json!({
+            "type": "adr",
+            "schema": FIXTURE_SCHEMA,
+            "auto_id": true,
+            "dir": dir.to_str().unwrap(),
+            "fields": ["author=example", "status=proposed"],
+        });
+        let obj = base.as_object_mut().unwrap();
+        for (k, v) in args.as_object().unwrap() {
+            obj.insert(k.clone(), v.clone());
+        }
+        tool_new(&base)
+    }
+
+    #[test]
+    fn title_arg_sets_h1_and_slug() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = new_adr(tmp.path(), json!({ "title": "SDK Architecture" })).unwrap();
+        let path = out["path"].as_str().unwrap();
+        assert!(
+            path.ends_with("docs/architecture/adr-001-sdk-architecture.md"),
+            "{path}"
+        );
+        assert!(out["content"]
+            .as_str()
+            .unwrap()
+            .contains("# SDK Architecture"));
+    }
+
+    #[test]
+    fn explicit_field_title_wins_over_title_arg() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = new_adr(
+            tmp.path(),
+            json!({ "title": "From Arg", "fields": ["author=example", "title=From Field"] }),
+        )
+        .unwrap();
+        assert!(out["path"]
+            .as_str()
+            .unwrap()
+            .ends_with("adr-001-from-field.md"));
+        assert!(out["content"].as_str().unwrap().contains("# From Field"));
+    }
+
+    #[test]
+    fn duplicate_title_slug_matches_h1() {
+        let tmp = tempfile::tempdir().unwrap();
+        let out = new_adr(
+            tmp.path(),
+            json!({ "fields": ["author=example", "title=First Alpha", "title=Second Beta"] }),
+        )
+        .unwrap();
+        // last title wins for BOTH the H1 and the slug
+        assert!(out["path"]
+            .as_str()
+            .unwrap()
+            .ends_with("adr-001-second-beta.md"));
+        assert!(out["content"].as_str().unwrap().contains("# Second Beta"));
+    }
+
+    #[test]
+    fn empty_slug_title_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        // non-ASCII-only title slugifies to nothing -> must error, not write {id}.md
+        let err = new_adr(tmp.path(), json!({ "title": "データベース移行" })).unwrap_err();
+        assert!(err.to_string().contains("empty filename slug"), "{err}");
+        // and nothing was written
+        assert!(!tmp.path().join("docs/architecture/adr-001.md").exists());
+    }
+
+    #[test]
+    fn no_title_under_auto_id_is_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        // under auto_id a title is required (CLI parity); a bare {id}.md fails F011
+        let err = new_adr(tmp.path(), json!({})).unwrap_err();
+        assert!(err.to_string().contains("title is required"), "{err}");
+        assert!(!tmp.path().join("docs/architecture/adr-001.md").exists());
+    }
 }

--- a/crates/md-db/src/template.rs
+++ b/crates/md-db/src/template.rs
@@ -79,6 +79,20 @@ pub fn generate_document_opts(
     out
 }
 
+/// Title -> filename slug, shared by `dg new` (CLI) and the `dg-new` MCP tool so
+/// both derive identical filenames (e.g. `"Use PostgreSQL!"` -> `use-postgresql`).
+pub fn slugify(title: &str) -> String {
+    title
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect::<String>()
+        .split('-')
+        .filter(|s| !s.is_empty())
+        .collect::<Vec<_>>()
+        .join("-")
+}
+
 fn default_value(field_def: &FieldDef, fill: bool) -> Value {
     // Schema-defined default takes priority
     if let Some(ref default_str) = field_def.default {
@@ -525,5 +539,26 @@ type "test" {
         assert!(y >= 2024 && y <= 2100);
         assert!((1..=12).contains(&m));
         assert!((1..=31).contains(&d));
+    }
+
+    #[test]
+    fn test_slugify() {
+        assert_eq!(slugify("Use PostgreSQL!"), "use-postgresql");
+        assert_eq!(
+            slugify("SDK Architecture For Partner Integrations"),
+            "sdk-architecture-for-partner-integrations"
+        );
+        // leading / trailing / consecutive separators collapse
+        assert_eq!(slugify("  --Hello,, World--  "), "hello-world");
+        assert_eq!(slugify("a.b/c"), "a-b-c");
+        // path-traversal characters are neutralised to separators
+        assert_eq!(slugify("../../etc/passwd"), "etc-passwd");
+        // digits are kept
+        assert_eq!(slugify("ADR 42 v2"), "adr-42-v2");
+        // empty / punctuation-only / non-ASCII-only -> empty slug
+        assert_eq!(slugify(""), "");
+        assert_eq!(slugify("!!!"), "");
+        assert_eq!(slugify("データベース移行"), "");
+        assert_eq!(slugify("Привет"), "");
     }
 }


### PR DESCRIPTION
## Problem
The `dg-new` MCP tool could create documents but had no title input: it only
accepted type/schema/fields/section_sets/auto_id/dir/output. The `dg new` CLI
takes a positional TITLE that drives both the H1 heading and the auto-id
filename slug; the MCP handler ignored it. As a result every MCP-created
document got an `# Untitled` H1 and, under auto_id, a bare `{id}.md` filename
that fails F011 validation ("filename is missing a descriptive slug"). An
MCP-only client (no shell) could not produce a valid, titled document in one
call.

## Changes
- **md-db** (`template.rs`): extract `pub fn slugify(&str)` (the CLI's slug
  algorithm) as a shared source of truth so the CLI and the MCP tool derive
  identical filenames; add a table test for it.
- **dg-cli** (`new.rs`): use `template::slugify`; drop the byte-identical local
  `slugify_title`. CLI output is unchanged.
- **dg-mcp** (`main.rs`): declare an optional `title` in the dg-new inputSchema.
- **dg-mcp** (`tools.rs`): `tool_new` now reads `title`, feeds it to the
  template's H1 override, and derives the auto-id filename slug from it. The
  LAST `title=` wins (matching the H1, which the template renders
  last-write-wins), so the slug and the heading cannot disagree. Under auto_id
  a title is REQUIRED and must yield a non-empty slug: a missing title, or one
  that slugifies to nothing (punctuation-/non-ASCII-only), is rejected with a
  clear error instead of silently writing an F011-invalid `{id}.md` — full
  parity with the CLI, which also bails. With an explicit `output` path the
  title stays optional and only sets the H1. An explicit `title=` in `fields`
  takes precedence over the dedicated `title` arg. Adds unit tests covering
  title->H1+slug, fields precedence, duplicate-title agreement, empty-slug
  rejection, and no-title rejection under auto_id.

## Backward compatibility
- `title` is optional and additive for the `output` path.
- Under auto_id, a title is now required (previously the tool wrote an
  F011-invalid `{id}.md`); callers must pass a title to get a valid document.
- Callers that previously passed `fields=["title=..."]` now receive a slugged
  `{id}-{slug}.md` under auto_id instead of `{id}.md`.

## Verification
- `cargo build -p dg-cli -p dg-mcp` and `cargo test -p md-db -p dg-mcp` pass.
- Patch adds no new clippy warnings on the touched code.
- End-to-end MCP JSON-RPC: titled auto_id -> `{id}-{slug}.md` + matching H1 and
  validates clean; missing/non-ASCII title under auto_id is rejected and writes
  nothing; explicit-output without a title still works; the CLI `dg new` path is
  unchanged.
- No new runtime dependencies (`tempfile` added only as a dev-dependency).
