### PR TITLE
fix: version consistency, dg --version, and credential-solid release→tap pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,6 +140,17 @@ jobs:
     needs: release
     runs-on: ubuntu-latest
     steps:
+      # Mint a short-lived token scoped to the tap repo. Replaces GH_PAT: no
+      # expiry to manage, and access is limited to decisiongraph/homebrew-tap.
+      - name: Mint a scoped token for the tap
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ secrets.TAP_APP_CLIENT_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          owner: decisiongraph
+          repositories: homebrew-tap
+
       - name: Download release artifacts
         uses: actions/download-artifact@v4
         with:
@@ -148,15 +159,16 @@ jobs:
 
       - name: Update homebrew-tap formula
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
           export VERSION="${TAG#v}"
-          git clone "https://x-access-token:${GH_PAT}@github.com/decisiongraph/homebrew-tap.git" tap
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/decisiongraph/homebrew-tap.git" tap
           cd tap
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
+          git config user.email "${APP_SLUG}[bot]@users.noreply.github.com"
+          git config user.name "${APP_SLUG}[bot]"
 
           python3 - <<'PYEOF'
           import re, os, hashlib, sys

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,25 @@ permissions:
   contents: write
 
 jobs:
+  version-check:
+    name: Assert tag matches Cargo.toml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compare git tag with workspace version
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME#v}"
+          CARGO_VERSION="$(grep -m1 '^version = ' Cargo.toml | sed -E 's/version = "(.*)"/\1/')"
+          echo "git tag: ${TAG} | Cargo.toml: ${CARGO_VERSION}"
+          if [ "${TAG}" != "${CARGO_VERSION}" ]; then
+            echo "::error::Tag v${TAG} does not match workspace version ${CARGO_VERSION}. Bump [workspace.package] version in Cargo.toml before tagging."
+            exit 1
+          fi
+
   build:
     name: Build ${{ matrix.target }}
+    needs: version-check
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -133,6 +150,7 @@ jobs:
         env:
           GH_PAT: ${{ secrets.GH_PAT }}
         run: |
+          set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
           export VERSION="${TAG#v}"
           git clone "https://x-access-token:${GH_PAT}@github.com/decisiongraph/homebrew-tap.git" tap
@@ -141,17 +159,25 @@ jobs:
           git config user.name "github-actions[bot]"
 
           python3 - <<'PYEOF'
-          import re, os, hashlib
+          import re, os, hashlib, sys
 
           def sha256(path):
               with open(path, "rb") as f:
                   return hashlib.sha256(f.read()).hexdigest()
 
+          def sub_once(pattern, repl, text, what, flags=0):
+              new, n = re.subn(pattern, repl, text, flags=flags)
+              if n != 1:
+                  sys.exit(f"::error::expected exactly 1 match for {what}, got {n}. "
+                           "Formula/dg.rb structure changed — refusing to publish a broken formula.")
+              return new
+
           version = os.environ["VERSION"]
           with open("Formula/dg.rb") as f:
               content = f.read()
 
-          content = re.sub(r'(version\s+")([^"]+)(")', rf'\g<1>{version}\g<3>', content)
+          # The download URLs interpolate #{version}, so only version + sha256 need updating.
+          content = sub_once(r'(version\s+")([^"]+)(")', rf'\g<1>{version}\g<3>', content, "version")
 
           assets = [
               "dg-aarch64-apple-darwin.tar.gz",
@@ -161,10 +187,10 @@ jobs:
           ]
           for asset in assets:
               digest = sha256(f"../dist/{asset}")
-              content = re.sub(
+              content = sub_once(
                   r'(url\s+"[^"]*' + re.escape(asset) + r'[^"]*"\n\s+sha256\s+")[a-f0-9]+(")',
                   rf'\g<1>{digest}\g<2>',
-                  content, flags=re.DOTALL
+                  content, f"sha256 of {asset}", flags=re.DOTALL,
               )
 
           with open("Formula/dg.rb", "w") as f:
@@ -172,5 +198,9 @@ jobs:
           PYEOF
 
           git add Formula/dg.rb
+          if git diff --cached --quiet; then
+            echo "Formula already up to date for ${TAG}; nothing to commit."
+            exit 0
+          fi
           git commit --no-gpg-sign -m "chore: update dg to ${TAG}"
           git push origin HEAD

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 exclude = ["cc-eval"]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 
 [workspace.dependencies]
 md-db = { path = "crates/md-db", features = ["diagrams", "gherkin"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ members = [
 ]
 exclude = ["cc-eval"]
 
+[workspace.package]
+version = "0.1.7"
+
 [workspace.dependencies]
 md-db = { path = "crates/md-db", features = ["diagrams", "gherkin"] }
 dg-gherkin = { path = "crates/gherkin" }

--- a/crates/dg-cli/Cargo.toml
+++ b/crates/dg-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dg-cli"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "DecisionGraph CLI — opinionated document management for decisions, policies, opportunities, and incidents"
 

--- a/crates/dg-cli/src/main.rs
+++ b/crates/dg-cli/src/main.rs
@@ -10,6 +10,7 @@ use commands::Command;
 #[derive(Parser)]
 #[command(
     name = "dg",
+    version,
     about = "DecisionGraph — structured decision documentation"
 )]
 struct Cli {

--- a/crates/dg-mcp/Cargo.toml
+++ b/crates/dg-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dg-mcp"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "DecisionGraph MCP server — AI agent integration via JSON-RPC over stdio"

--- a/crates/dg-schemas/Cargo.toml
+++ b/crates/dg-schemas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dg-schemas"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Built-in KDL schemas for DecisionGraph document types (OPP/POL/ADR/INC)"
 

--- a/crates/gherkin/Cargo.toml
+++ b/crates/gherkin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dg-gherkin"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Gherkin parsing, semantic validation, and diagram generation for DecisionGraph"
 

--- a/crates/markdown-tui/Cargo.toml
+++ b/crates/markdown-tui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "markdown-tui"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 description = "Render GitHub Flavored Markdown beautifully in terminal UIs with ratatui"
 license = "MIT"

--- a/crates/markdown-tui/src/blocks/table.rs
+++ b/crates/markdown-tui/src/blocks/table.rs
@@ -518,42 +518,6 @@ fn prepend_number_column(rows: &mut [Vec<Vec<StyledSegment>>]) {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::types::{SegmentStyle, StyledSegment};
-
-    fn plain_cell(text: &str) -> Vec<StyledSegment> {
-        vec![StyledSegment {
-            text: text.to_string(),
-            style: SegmentStyle::default(),
-        }]
-    }
-
-    #[test]
-    fn test_prepend_number_column() {
-        let mut rows = vec![
-            vec![plain_cell("Name"), plain_cell("Score")],
-            vec![plain_cell("Alice"), plain_cell("8")],
-            vec![plain_cell("Bob"), plain_cell("6")],
-        ];
-        prepend_number_column(&mut rows);
-
-        assert_eq!(rows[0][0][0].text, "#");
-        assert_eq!(rows[1][0][0].text, "1");
-        assert_eq!(rows[2][0][0].text, "2");
-        assert_eq!(rows[0].len(), 3);
-        assert_eq!(rows[1].len(), 3);
-    }
-
-    #[test]
-    fn test_prepend_number_column_empty() {
-        let mut rows: Vec<Vec<Vec<StyledSegment>>> = vec![];
-        prepend_number_column(&mut rows);
-        assert!(rows.is_empty());
-    }
-}
-
 /// Render a table from raw string data (not from markdown AST).
 ///
 /// `headers` — column header labels
@@ -604,4 +568,40 @@ pub fn render_table_from_data(
     let alignments = vec![Alignment::Left; headers.len()];
     let lines = render_table_inner(&styled_rows, &alignments, options);
     RenderedBlock::Lines(lines)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{SegmentStyle, StyledSegment};
+
+    fn plain_cell(text: &str) -> Vec<StyledSegment> {
+        vec![StyledSegment {
+            text: text.to_string(),
+            style: SegmentStyle::default(),
+        }]
+    }
+
+    #[test]
+    fn test_prepend_number_column() {
+        let mut rows = vec![
+            vec![plain_cell("Name"), plain_cell("Score")],
+            vec![plain_cell("Alice"), plain_cell("8")],
+            vec![plain_cell("Bob"), plain_cell("6")],
+        ];
+        prepend_number_column(&mut rows);
+
+        assert_eq!(rows[0][0][0].text, "#");
+        assert_eq!(rows[1][0][0].text, "1");
+        assert_eq!(rows[2][0][0].text, "2");
+        assert_eq!(rows[0].len(), 3);
+        assert_eq!(rows[1].len(), 3);
+    }
+
+    #[test]
+    fn test_prepend_number_column_empty() {
+        let mut rows: Vec<Vec<Vec<StyledSegment>>> = vec![];
+        prepend_number_column(&mut rows);
+        assert!(rows.is_empty());
+    }
 }

--- a/crates/md-db/Cargo.toml
+++ b/crates/md-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "md-db"
-version = "0.1.0"
+version.workspace = true
 edition = "2021"
 license = "AGPL-3.0-or-later"
 description = "Markdown-as-Database library — structured documents with YAML frontmatter validated against KDL schemas"

--- a/crates/md-db/src/graph.rs
+++ b/crates/md-db/src/graph.rs
@@ -1129,7 +1129,7 @@ mod tests {
 
         // First build populates cache
         let g1 = DocGraph::build_cached("../../tests/fixtures", &schema, &mut cache).unwrap();
-        assert!(cache.len() > 0);
+        assert!(!cache.is_empty());
 
         // Second build reuses cache (no files changed)
         let g2 = DocGraph::build_cached("../../tests/fixtures", &schema, &mut cache).unwrap();

--- a/crates/md-db/src/suggest.rs
+++ b/crates/md-db/src/suggest.rs
@@ -817,7 +817,7 @@ mod tests {
         assert_eq!(days_between("2025-01-14", "2025-01-15"), Some(-1));
         // ~90 days
         let diff = days_between("2025-04-15", "2025-01-15").unwrap();
-        assert!(diff >= 89 && diff <= 91);
+        assert!((89..=91).contains(&diff));
     }
 
     // ─── Incomplete markers ────────────────────────────────────────────────

--- a/crates/md-db/src/template.rs
+++ b/crates/md-db/src/template.rs
@@ -536,7 +536,7 @@ type "test" {
     fn test_civil_date_sanity() {
         // Just ensure it returns a plausible date
         let (y, m, d) = civil_date_from_epoch();
-        assert!(y >= 2024 && y <= 2100);
+        assert!((2024..=2100).contains(&y));
         assert!((1..=12).contains(&m));
         assert!((1..=31).contains(&d));
     }

--- a/crates/md-db/src/validation/mod.rs
+++ b/crates/md-db/src/validation/mod.rs
@@ -10,9 +10,9 @@ pub use types::{Diagnostic, FileResult, Severity, ValidationResult};
 // Re-export commonly used types for tests and internal use
 // Re-exports for test access (tests use `use super::*`)
 #[cfg(test)]
-use crate::document::{Document, ParsedBody};
+use crate::document::Document;
 #[cfg(test)]
-use crate::schema::{FieldDef, FieldType, Schema, SectionDef, TableDef, TypeDef};
+use crate::schema::Schema;
 #[cfg(test)]
 use crate::users::OrgConfig;
 #[cfg(test)]
@@ -24,7 +24,7 @@ pub(crate) use directory::{
 #[cfg(test)]
 pub(crate) use document::singleton_matches;
 #[cfg(test)]
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 #[cfg(test)]
 use std::path::{Path, PathBuf};
 

--- a/crates/md-db/tests/fixtures_test.rs
+++ b/crates/md-db/tests/fixtures_test.rs
@@ -428,7 +428,7 @@ fn adr_001_to_json() {
     assert_eq!(json["frontmatter"]["status"], "accepted");
     assert_eq!(json["frontmatter"]["author"], "onni");
     // Top-level section is the H1 title; H2s are subsections under it
-    assert!(json["sections"].as_array().unwrap().len() >= 1);
+    assert!(!json["sections"].as_array().unwrap().is_empty());
 }
 
 // ─── Schema parsing ─────────────────────────────────────────────────────────

--- a/ui/src/routes/roadmap/+page.svelte
+++ b/ui/src/routes/roadmap/+page.svelte
@@ -9,6 +9,8 @@
 	const roadmapData = $derived(data.roadmap as RoadmapData | null);
 	const generatedAt = $derived(roadmapData?.generated_at);
 
+	let container: HTMLElement | undefined = $state();
+
 	/** Map doc type prefix to folder for SPA routes */
 	const prefixToFolder: Record<string, string> = {
 		adr: 'architecture',
@@ -38,6 +40,14 @@
 				}
 			}
 		});
+	});
+
+	/** Attach click delegation to the pre-rendered roadmap container (anchors are the real targets) */
+	$effect(() => {
+		const el = container;
+		if (!el) return;
+		el.addEventListener('click', handleClick);
+		return () => el.removeEventListener('click', handleClick);
 	});
 
 	/** Intercept clicks on .html links from pre-rendered roadmap and navigate via SPA */
@@ -81,8 +91,7 @@
 	</div>
 
 	{#if roadmapData?.html}
-		<!-- svelte-ignore a11y_click_events_have_key_events a11y_no_static_element_interactions -->
-		<div class="roadmap-container rounded-xl border bg-card p-6 shadow-sm" onclick={handleClick}>
+		<div class="roadmap-container rounded-xl border bg-card p-6 shadow-sm" bind:this={container}>
 			<HtmlContent html={roadmapData.html} />
 		</div>
 	{:else}


### PR DESCRIPTION
Session cleanup covering repo lint hygiene, a version single-source-of-truth, and hardening the automated release + Homebrew tap update (which was silently broken).

## Lint / warnings
- Resolve all `clippy` warnings (unused imports, `manual_range_contains`, `len_zero`, `items_after_test_module`) — restores the zero-warning policy the git hook enforces (`denyWarnings`).
- Fix a `svelte-check` a11y warning in `roadmap/+page.svelte` by attaching the click-delegation listener via `bind:this` + `$effect` instead of an inline `onclick` on a static div.

## Version single-source-of-truth
Previously every crate was pinned at `0.1.0` while releases were tagged `v0.1.7`, and `dg` had no `--version` flag at all.
- Add `[workspace.package] version = "0.1.7"`; all 6 crates use `version.workspace = true` (bump in lockstep).
- Add `version` to the clap command so `dg --version` works (also fixes the version reported in `dg-mcp`'s JSON-RPC handshake).

## Release pipeline (`.github/workflows/release.yml`)
- Add a `version-check` job that fails the release if the pushed tag ≠ workspace version (mirrors the existing pre-push hook, but CI can't be `--no-verify`'d).
- Harden the tap update: `set -euo pipefail` + fail-loud `sub_once` guards so a structural mismatch errors instead of silently shipping a broken formula; no-op when unchanged.
- **Replace the expired `GH_PAT`** with a short-lived token minted per run via `actions/create-github-app-token@v3`, scoped to `decisiongraph/homebrew-tap`. No expiry to manage, access limited to that one repo.

## Companion changes (already merged / applied outside this branch)
- `decisiongraph/homebrew-tap#2` (merged): formula URLs now interpolate `v#{version}` instead of a frozen `v0.1.0` — the bug that made `brew install` fail its checksum.
- Secrets: added `TAP_APP_CLIENT_ID` + `TAP_APP_PRIVATE_KEY` (GitHub App `dg-tap-updater`, Contents: write on the tap); deleted the dead `GH_PAT`.

## Verification
- `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `cargo fmt --check`, `bun run check` — all clean.
- End-to-end CI self-test proved the App token mints, transforms the formula for a new version, and pushes to the tap.

## Release runbook (after merge)
Bump `[workspace.package] version`, tag the matching `vX.Y.Z`, push the tag.