### PR TITLE
Reserve document IDs across git clones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
 
 [[package]]
 name = "dg-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "dg-gherkin"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "gherkin",
  "insta",
@@ -798,7 +798,7 @@ dependencies = [
 
 [[package]]
 name = "dg-mcp"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "dg-schemas",
@@ -809,7 +809,7 @@ dependencies = [
 
 [[package]]
 name = "dg-schemas"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "md-db",
 ]
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "markdown-tui"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "color-eyre",
  "comrak",
@@ -1728,7 +1728,7 @@ dependencies = [
 
 [[package]]
 name = "md-db"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 exclude = ["cc-eval"]
 
 [workspace.package]
-version = "0.1.9"
+version = "0.1.10"
 
 [workspace.dependencies]
 md-db = { path = "crates/md-db", features = ["diagrams", "gherkin"] }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,14 @@ dg refs ADR-001 --backlinks          # Show what references ADR-001
 
 Type aliases: `opportunity`→opp, `architecture`/`tech`→adr, `policy`→pol, `incident`→inc, `feature`→spec.
 
+When the project is in a Git repository with a remote, `dg new` reserves numbers
+for every document type by pushing namespaced tags such as `dg/adr-001`. This
+prevents two contributors from selecting the same number concurrently. The
+`fork` remote is preferred, then `origin`, then the first configured remote.
+For older repositories without reservation tags, files on the remote's default
+branch are also scanned before choosing the next number. Projects without a
+remote continue to allocate numbers from local documents.
+
 ## Document types
 
 | Type | Aliases | Prefix | Folder | Purpose |

--- a/crates/dg-cli/src/commands/new.rs
+++ b/crates/dg-cli/src/commands/new.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::process::{Command, Output};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{bail, Context, Result};
@@ -210,6 +211,242 @@ fn today_epoch_days() -> i64 {
     (secs / 86400) as i64
 }
 
+const MAX_TAG_RESERVATION_ATTEMPTS: u32 = 100;
+
+/// Pick the remote used for ID reservations. A remote named `fork` is preferred
+/// so contributors do not need write access to the upstream repository.
+fn reservation_remote(root: &Path) -> Result<Option<String>> {
+    let repo = match git2::Repository::discover(root) {
+        Ok(repo) => repo,
+        Err(_) => return Ok(None),
+    };
+    let remotes = repo.remotes().context("failed to list git remotes")?;
+    let names: Vec<&str> = remotes
+        .iter()
+        .filter_map(|name| name.ok().flatten())
+        .collect();
+
+    Ok(names
+        .iter()
+        .find(|name| **name == "fork")
+        .or_else(|| names.iter().find(|name| **name == "origin"))
+        .or_else(|| names.first())
+        .map(|name| (*name).to_string()))
+}
+
+fn git_output(root: &Path, args: &[&str]) -> Result<Output> {
+    Command::new("git")
+        .args(args)
+        .current_dir(root)
+        .output()
+        .with_context(|| format!("failed to run `git {}`", args.join(" ")))
+}
+
+fn command_output_text(output: &Output) -> String {
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    format!("{stdout}{stderr}").trim().to_string()
+}
+
+fn max_tag_number(output: &[u8], tag_prefix: &str) -> Option<u32> {
+    let ref_prefix = format!("refs/tags/{tag_prefix}-");
+    let plain_prefix = format!("{tag_prefix}-");
+    String::from_utf8_lossy(output)
+        .lines()
+        .filter_map(|line| {
+            // `ls-remote` prints "<oid> refs/tags/<tag>" while `git tag
+            // --list` prints just the tag name.
+            let name = line.split_whitespace().last()?;
+            name.strip_prefix(&ref_prefix)
+                .or_else(|| name.strip_prefix(&plain_prefix))?
+                .parse::<u32>()
+                .ok()
+        })
+        .max()
+}
+
+fn tag_exists_on_remote(root: &Path, remote: &str, tag: &str) -> Result<bool> {
+    let output = git_output(root, &["ls-remote", "--tags", "--refs", remote, tag])?;
+    if !output.status.success() {
+        bail!(
+            "failed to check tag {tag} on git remote '{remote}': {}",
+            command_output_text(&output)
+        );
+    }
+    Ok(!output.stdout.is_empty())
+}
+
+fn max_document_number(output: &[u8], canonical_type: &str) -> Option<u32> {
+    let dash_prefix = format!("{}-", canonical_type.to_ascii_lowercase());
+    let underscore_prefix = format!("{}_", canonical_type.to_ascii_lowercase());
+    String::from_utf8_lossy(output)
+        .lines()
+        .filter_map(|line| {
+            let path = Path::new(line);
+            if !path
+                .extension()
+                .and_then(|extension| extension.to_str())
+                .is_some_and(|extension| extension.eq_ignore_ascii_case("md"))
+            {
+                return None;
+            }
+            let stem = path.file_stem()?.to_str()?.to_ascii_lowercase();
+            let suffix = stem
+                .strip_prefix(&dash_prefix)
+                .or_else(|| stem.strip_prefix(&underscore_prefix))?;
+            let digits: String = suffix
+                .chars()
+                .take_while(|character| character.is_ascii_digit())
+                .collect();
+            digits.parse::<u32>().ok()
+        })
+        .max()
+}
+
+/// Read document filenames from the remote's default branch. This bootstraps
+/// tag reservations for repositories that already contain numbered documents
+/// but predate the `dg/` reservation tags.
+fn max_remote_document_number(
+    root: &Path,
+    remote: &str,
+    folder: &str,
+    canonical_type: &str,
+) -> Result<Option<u32>> {
+    let head = git_output(root, &["ls-remote", "--symref", remote, "HEAD"])?;
+    if !head.status.success() {
+        bail!(
+            "failed to inspect the default branch on git remote '{remote}': {}",
+            command_output_text(&head)
+        );
+    }
+    let head_oid = String::from_utf8_lossy(&head.stdout)
+        .lines()
+        .find_map(|line| {
+            let (oid, name) = line.split_once('\t')?;
+            (name == "HEAD" && !oid.starts_with("ref: ")).then_some(oid.to_string())
+        });
+    let Some(head_oid) = head_oid else {
+        return Ok(None);
+    };
+
+    // Fetch the advertised commit by object ID and inspect that exact object,
+    // avoiding dependency on potentially stale remote-tracking branches.
+    let fetch = git_output(root, &["fetch", "--quiet", "--no-tags", remote, &head_oid])?;
+    if !fetch.status.success() {
+        bail!(
+            "failed to fetch the default branch from git remote '{remote}': {}",
+            command_output_text(&fetch)
+        );
+    }
+    let tree = git_output(
+        root,
+        &["ls-tree", "-r", "--name-only", &head_oid, "--", folder],
+    )?;
+    if !tree.status.success() {
+        bail!(
+            "failed to inspect documents on git remote '{remote}': {}",
+            command_output_text(&tree)
+        );
+    }
+    Ok(max_document_number(&tree.stdout, canonical_type))
+}
+
+/// Reserve a document ID by atomically creating a namespaced tag on a shared
+/// git remote. Returns the local-only ID unchanged when the project is not in a
+/// repository or has no remote.
+fn reserve_document_id(
+    root: &Path,
+    canonical_type: &str,
+    folder: &str,
+    local_next_id: &str,
+) -> Result<String> {
+    let Some(remote) = reservation_remote(root)? else {
+        return Ok(local_next_id.to_string());
+    };
+
+    let tag_prefix = format!("dg/{}", canonical_type.to_ascii_lowercase());
+    let pattern = format!("{tag_prefix}-*");
+    let remote_tags = git_output(root, &["ls-remote", "--tags", "--refs", &remote, &pattern])?;
+    if !remote_tags.status.success() {
+        bail!(
+            "failed to list ID reservation tags on git remote '{remote}': {}",
+            command_output_text(&remote_tags)
+        );
+    }
+    let local_tags = git_output(root, &["tag", "--list", &pattern])?;
+    if !local_tags.status.success() {
+        bail!(
+            "failed to list local git tags: {}",
+            command_output_text(&local_tags)
+        );
+    }
+
+    let local_floor = local_next_id
+        .split_once('-')
+        .and_then(|(_, number)| number.parse::<u32>().ok())
+        .unwrap_or(1);
+    let remote_document_floor = max_remote_document_number(root, &remote, folder, canonical_type)?
+        .unwrap_or(0)
+        .saturating_add(1);
+    let mut candidate = local_floor
+        .max(max_tag_number(&remote_tags.stdout, &tag_prefix).unwrap_or(0) + 1)
+        .max(max_tag_number(&local_tags.stdout, &tag_prefix).unwrap_or(0) + 1)
+        .max(remote_document_floor);
+
+    for _ in 0..MAX_TAG_RESERVATION_ATTEMPTS {
+        let tag = format!("{tag_prefix}-{candidate:03}");
+        let create = git_output(root, &["-c", "tag.gpgSign=false", "tag", &tag])?;
+        if !create.status.success() {
+            // A local process may have reserved this number after our initial scan.
+            let verify_ref = format!("refs/tags/{tag}");
+            let exists = git_output(root, &["show-ref", "--verify", "--quiet", &verify_ref])?;
+            if exists.status.success() {
+                candidate += 1;
+                continue;
+            }
+            bail!(
+                "failed to create reservation tag {tag}: {}",
+                command_output_text(&create)
+            );
+        }
+
+        let refspec = format!("refs/tags/{tag}:refs/tags/{tag}");
+        let push = git_output(root, &["push", "--porcelain", &remote, &refspec])?;
+        let push_text = command_output_text(&push);
+        let created = push.status.success()
+            && push_text.lines().any(|line| {
+                line.starts_with('*') && line.contains(&format!("refs/tags/{tag}:refs/tags/{tag}"))
+            });
+        if created {
+            return Ok(format!(
+                "{}-{candidate:03}",
+                canonical_type.to_ascii_uppercase()
+            ));
+        }
+
+        // Keep local tags only for successful reservations. If the remote now
+        // has this tag, another creator won the race (or the push was already
+        // up to date), so advance to the next number.
+        let delete = git_output(root, &["tag", "--delete", &tag])?;
+        if !delete.status.success() {
+            bail!(
+                "failed to remove unreserved local tag {tag}: {}",
+                command_output_text(&delete)
+            );
+        }
+        if push.status.success() || tag_exists_on_remote(root, &remote, &tag)? {
+            candidate += 1;
+            continue;
+        }
+
+        bail!("failed to reserve {tag} on git remote '{remote}': {push_text}");
+    }
+
+    bail!(
+        "failed to reserve a {tag_prefix} document ID after {MAX_TAG_RESERVATION_ATTEMPTS} attempts"
+    )
+}
+
 pub fn run(
     root: &Path,
     schema: &Schema,
@@ -273,7 +510,7 @@ pub fn run(
     // Warn if any user values are unknown
     warn_unknown_users(&fields, type_def, org);
 
-    let next_id = graph.next_id(canonical_type);
+    let local_next_id = graph.next_id(canonical_type);
 
     let folder = type_def.folder.as_deref().unwrap_or("docs");
     let slug = parsed
@@ -281,23 +518,22 @@ pub fn run(
         .as_deref()
         .map(template::slugify)
         .unwrap_or_default();
-    let filename = if slug.is_empty() {
+    if slug.is_empty() {
         bail!("title is required (used for filename slug)");
-    } else {
-        format!("{}-{slug}.md", next_id.to_lowercase())
-    };
-    let path = root.join(folder).join(&filename);
+    }
 
     // Ensure parent dir exists
-    if let Some(parent) = path.parent() {
-        if !parent.exists() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("failed to create {}", parent.display()))?;
-        }
+    let parent = root.join(folder);
+    if !parent.exists() {
+        std::fs::create_dir_all(&parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
     }
 
     let content =
         template::generate_document_opts(type_def, schema, &fields, &parsed.rels, parsed.fill);
+    let next_id = reserve_document_id(root, canonical_type, folder, &local_next_id)?;
+    let filename = format!("{}-{slug}.md", next_id.to_lowercase());
+    let path = parent.join(&filename);
     std::fs::write(&path, &content)
         .with_context(|| format!("failed to write {}", path.display()))?;
 
@@ -320,10 +556,75 @@ pub fn run(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
 
     fn fixture_schema() -> Schema {
         let content = std::fs::read_to_string("../../tests/fixtures/schema.kdl").unwrap();
         Schema::from_str(&content).unwrap()
+    }
+
+    fn run_git(dir: &Path, args: &[&str]) -> Output {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "git {} failed: {}",
+            args.join(" "),
+            command_output_text(&output)
+        );
+        output
+    }
+
+    fn init_git_repo() -> (TempDir, std::path::PathBuf, std::path::PathBuf) {
+        let temp = TempDir::new().unwrap();
+        let work = temp.path().join("work");
+        let remote = temp.path().join("origin.git");
+        run_git(
+            temp.path(),
+            &[
+                "init",
+                "--quiet",
+                "--bare",
+                "--initial-branch=main",
+                remote.to_str().unwrap(),
+            ],
+        );
+        run_git(
+            temp.path(),
+            &[
+                "init",
+                "--quiet",
+                "--initial-branch=main",
+                work.to_str().unwrap(),
+            ],
+        );
+        run_git(&work, &["config", "user.name", "Test User"]);
+        run_git(&work, &["config", "user.email", "test@example.com"]);
+        std::fs::write(work.join("README.md"), "test\n").unwrap();
+        run_git(&work, &["add", "README.md"]);
+        run_git(
+            &work,
+            &[
+                "-c",
+                "commit.gpgSign=false",
+                "commit",
+                "--quiet",
+                "-m",
+                "initial",
+            ],
+        );
+        run_git(
+            &work,
+            &["remote", "add", "origin", remote.to_str().unwrap()],
+        );
+        run_git(
+            &work,
+            &["push", "--quiet", "origin", "HEAD:refs/heads/main"],
+        );
+        (temp, work, remote)
     }
 
     #[test]
@@ -533,5 +834,159 @@ mod tests {
         let type_def = schema.get_type("adr").unwrap();
         // No org config — should not panic
         warn_unknown_users(&[("author".into(), "anyone".into())], type_def, None);
+    }
+
+    #[test]
+    fn test_max_tag_number_parses_remote_and_local_tag_output() {
+        let remote = b"abc\trefs/tags/dg/adr-002\ndef\trefs/tags/dg/adr-014\n";
+        assert_eq!(max_tag_number(remote, "dg/adr"), Some(14));
+        assert_eq!(
+            max_tag_number(b"dg/adr-003\ndg/adr-not-a-number\n", "dg/adr"),
+            Some(3)
+        );
+    }
+
+    #[test]
+    fn test_max_document_number_parses_numbered_markdown_files() {
+        let files = b"docs/architecture/adr-002-old.md\ndocs/architecture/ADR_155.md\ndocs/architecture/adr-not-numbered.md\ndocs/architecture/adr-999.txt\n";
+        assert_eq!(max_document_number(files, "adr"), Some(155));
+    }
+
+    #[test]
+    fn test_reserve_document_id_pushes_incrementing_tags() {
+        let (_temp, work, remote) = init_git_repo();
+
+        assert_eq!(
+            reserve_document_id(&work, "adr", "docs", "ADR-001").unwrap(),
+            "ADR-001"
+        );
+        assert_eq!(
+            reserve_document_id(&work, "adr", "docs", "ADR-001").unwrap(),
+            "ADR-002"
+        );
+
+        let tags = run_git(
+            &work,
+            &[
+                "ls-remote",
+                "--tags",
+                "--refs",
+                remote.to_str().unwrap(),
+                "dg/adr-*",
+            ],
+        );
+        let tags = String::from_utf8_lossy(&tags.stdout);
+        assert!(tags.contains("refs/tags/dg/adr-001"));
+        assert!(tags.contains("refs/tags/dg/adr-002"));
+    }
+
+    #[test]
+    fn test_reservation_prefers_fork_over_origin() {
+        let (temp, work, origin) = init_git_repo();
+        let fork = temp.path().join("fork.git");
+        run_git(
+            temp.path(),
+            &["init", "--quiet", "--bare", fork.to_str().unwrap()],
+        );
+        run_git(&work, &["remote", "add", "fork", fork.to_str().unwrap()]);
+
+        assert_eq!(
+            reserve_document_id(&work, "opp", "docs", "OPP-001").unwrap(),
+            "OPP-001"
+        );
+
+        let fork_tags = run_git(
+            &work,
+            &[
+                "ls-remote",
+                "--tags",
+                "--refs",
+                fork.to_str().unwrap(),
+                "dg/opp-*",
+            ],
+        );
+        let origin_tags = run_git(
+            &work,
+            &[
+                "ls-remote",
+                "--tags",
+                "--refs",
+                origin.to_str().unwrap(),
+                "dg/opp-*",
+            ],
+        );
+        assert!(String::from_utf8_lossy(&fork_tags.stdout).contains("refs/tags/dg/opp-001"));
+        assert!(origin_tags.stdout.is_empty());
+    }
+
+    #[test]
+    fn test_reservation_applies_to_any_document_type() {
+        let (_temp, work, remote) = init_git_repo();
+
+        assert_eq!(
+            reserve_document_id(&work, "custom", "docs", "CUSTOM-009").unwrap(),
+            "CUSTOM-009"
+        );
+
+        let tags = run_git(
+            &work,
+            &[
+                "ls-remote",
+                "--tags",
+                "--refs",
+                remote.to_str().unwrap(),
+                "dg/custom-*",
+            ],
+        );
+        assert!(String::from_utf8_lossy(&tags.stdout).contains("refs/tags/dg/custom-009"));
+    }
+
+    #[test]
+    fn test_reservation_accounts_for_documents_in_older_remote_repo() {
+        let (_temp, work, remote) = init_git_repo();
+        let policies = work.join("docs/policies");
+        std::fs::create_dir_all(&policies).unwrap();
+        std::fs::write(policies.join("pol-155-existing.md"), "# Existing policy\n").unwrap();
+        run_git(&work, &["add", "docs/policies/pol-155-existing.md"]);
+        run_git(
+            &work,
+            &[
+                "-c",
+                "commit.gpgSign=false",
+                "commit",
+                "--quiet",
+                "-m",
+                "add existing policy",
+            ],
+        );
+        run_git(
+            &work,
+            &["push", "--quiet", "origin", "HEAD:refs/heads/main"],
+        );
+
+        assert_eq!(
+            reserve_document_id(&work, "pol", "docs/policies", "POL-001").unwrap(),
+            "POL-156"
+        );
+        let tags = run_git(
+            &work,
+            &[
+                "ls-remote",
+                "--tags",
+                "--refs",
+                remote.to_str().unwrap(),
+                "dg/pol-*",
+            ],
+        );
+        assert!(String::from_utf8_lossy(&tags.stdout).contains("refs/tags/dg/pol-156"));
+    }
+
+    #[test]
+    fn test_reservation_falls_back_without_git_remote() {
+        let temp = TempDir::new().unwrap();
+        assert_eq!(
+            reserve_document_id(temp.path(), "pol", "docs", "POL-007").unwrap(),
+            "POL-007"
+        );
     }
 }


### PR DESCRIPTION
## What changed

- reserve every dg document ID with a namespaced dg/type-NNN git tag
- prefer fork, then origin, then another configured remote
- retry atomically when simultaneous creators race
- scan numbered Markdown files on the remote default branch for tagless older repositories
- bump the workspace to v0.1.10

## Why

Local-only ID allocation lets two contributors in separate clones create the same document number. Remote tags provide a shared reservation ledger while the remote file scan preserves compatibility with existing repositories.

## Validation

- cargo fmt --all -- --check
- cargo metadata --locked --format-version 1
- DG_SKIP_UI_BUILD=1 cargo test --workspace --locked
- real two-clone concurrent CLI run produced ADR-001 and ADR-002 plus two remote tags
- real legacy remote with adr-155 produced ADR-156 and dg/adr-156