### PR TITLE
feat(validate): safe auto-install, devenv services, workspace-aware dependabot

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,18 +119,31 @@ dg set OPP-001 --remove tags                      # Remove a field
 # Validate & lint
 dg validate                          # Schema validation (errors + warnings)
 dg validate --skip C002              # Suppress specific diagnostic codes
-dg validate --no-install             # Don't auto-install JS deps before running tests/linters
+dg validate --no-install             # Don't auto-install deps / start devenv services before checks
 dg lint                              # Validate + graph health (orphans, cycles, dangling refs)
 # GitHub-hosted projects: warns when detected package ecosystems (cargo, npm, mix,
 # docker, terraform, opentofu, nix, ...) lack .github/dependabot.yml coverage
 # (SV011/SV012) — OpenTofu is told apart from Terraform via .tofu files,
 # .opentofu-version, lockfile registry.opentofu.org providers, or dir name —
 # and when devenv.lock has no scheduled `devenv update` workflow (SV013).
+# npm workspace members (pnpm-workspace.yaml packages / package.json workspaces)
+# are covered by a root npm entry; standalone package.json dirs outside the
+# workspace need their own entry and are listed individually when missing.
 # Service tests/linters run via the detected JS package manager (packageManager
-# field or lockfile: bun/pnpm/yarn/npm); missing node_modules are installed
-# automatically first (SV014 warns when that's not possible). Binaries missing
-# from PATH are run through devenv/mise/nix/direnv when a matching config
-# (devenv.nix, mise.toml, .tool-versions, flake.nix, .envrc) exists at the root.
+# field or lockfile: bun/pnpm/yarn/npm); missing node_modules and Elixir deps/
+# are installed automatically first (SV014 warns when that's not possible).
+# Installs that can execute dependency scripts (npm/yarn) only run after an
+# interactive [y/N] confirmation; pnpm/bun block untrusted scripts themselves
+# and `mix deps.get` only fetches, so those run unattended. A pnpm install
+# blocked on unapproved build scripts still counts as installed, with SV018
+# pointing at `pnpm approve-builds` / unresolved allowBuilds placeholders.
+# Deprecated frontmatter keys removed from dg (e.g. code_paths) are errors (F023).
+# Binaries missing from PATH are run through devenv/mise/nix/direnv when a
+# matching config (devenv.nix, mise.toml, .tool-versions, flake.nix, .envrc)
+# exists at the root. When devenv.nix declares services (postgres, redis, ...),
+# they are started for the duration of the checks (`devenv up -d` + readiness
+# wait) and stopped afterwards unless they were already running; SV019 warns
+# when starting fails.
 # Phoenix services whose config/test.exs binds a hardcoded port with
 # `server: true` (Wallaby setups) get SV015 suggesting `port: 0` + a runtime-
 # resolved base_url, so parallel test runs can't collide.

--- a/crates/dg-cli/src/commands/init.rs
+++ b/crates/dg-cli/src/commands/init.rs
@@ -258,7 +258,8 @@ fn setup_dependabot(root: &Path, force: bool) -> Result<()> {
         return Ok(());
     }
 
-    let hits = db::detect_ecosystems(root);
+    // npm workspace members are covered by the generated root entry.
+    let hits = db::detect_ecosystems(root).config_hits();
     if !hits.is_empty() && db::find_config(root).is_none() {
         let labels: Vec<String> = hits.iter().map(db::EcosystemHit::label).collect();
         eprintln!("  dependabot: detected {}", labels.join(", "));

--- a/crates/dg-cli/src/commands/lint.rs
+++ b/crates/dg-cli/src/commands/lint.rs
@@ -13,7 +13,8 @@ pub struct LintArgs {
     #[arg(long)]
     pub pattern: Option<String>,
 
-    /// Skip auto-installing JS dependencies before running tests/linters
+    /// Skip auto-installing JS/mix dependencies and starting devenv services
+    /// before running tests/linters
     #[arg(long)]
     pub no_install: bool,
 }
@@ -35,6 +36,7 @@ pub fn run(
     let opts = validation::ServiceCheckOptions {
         no_install: args.no_install,
         progress: crate::progress::stderr_sink(),
+        confirm: crate::progress::install_confirm(),
     };
     let outcome = validation::validate_service_checks(root, &opts);
     result.file_results.extend(outcome.file_results);

--- a/crates/dg-cli/src/commands/validate.rs
+++ b/crates/dg-cli/src/commands/validate.rs
@@ -24,7 +24,8 @@ pub struct ValidateArgs {
     #[arg(long, value_delimiter = ',')]
     pub skip: Vec<String>,
 
-    /// Skip auto-installing JS dependencies before running tests/linters
+    /// Skip auto-installing JS/mix dependencies and starting devenv services
+    /// before running tests/linters
     #[arg(long)]
     pub no_install: bool,
 }
@@ -55,6 +56,7 @@ pub fn run(
         let opts = validation::ServiceCheckOptions {
             no_install: args.no_install,
             progress: crate::progress::stderr_sink(),
+            confirm: crate::progress::install_confirm(),
         };
         let outcome = validation::validate_service_checks(root, &opts);
         result.file_results.extend(outcome.file_results);

--- a/crates/dg-cli/src/progress.rs
+++ b/crates/dg-cli/src/progress.rs
@@ -25,6 +25,24 @@ pub fn stderr_sink() -> Option<Arc<dyn ProgressSink>> {
     }
 }
 
+/// Interactive confirmation for installs that may execute dependency
+/// scripts (npm/yarn). `None` when stdin/stderr are not TTYs, so CI and
+/// piped runs never hang on a prompt.
+pub fn install_confirm() -> Option<md_db::toolchain::ConfirmFn> {
+    if !std::io::stdin().is_terminal() || !std::io::stderr().is_terminal() {
+        return None;
+    }
+    Some(Arc::new(|message: &str| {
+        eprint!("dg: {message} [y/N] ");
+        let _ = std::io::stderr().flush();
+        let mut line = String::new();
+        if std::io::stdin().read_line(&mut line).is_err() {
+            return false;
+        }
+        matches!(line.trim().to_ascii_lowercase().as_str(), "y" | "yes")
+    }))
+}
+
 const FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 const TICK: Duration = Duration::from_millis(100);
 

--- a/crates/md-db/src/dependabot.rs
+++ b/crates/md-db/src/dependabot.rs
@@ -26,6 +26,42 @@ impl EcosystemHit {
     }
 }
 
+/// Detected ecosystems plus npm workspace layout, so coverage checks can
+/// treat a root npm entry as covering workspace member manifests (Dependabot
+/// handles npm/yarn/pnpm workspaces from the workspace root).
+#[derive(Debug, Default)]
+pub struct EcosystemScan {
+    /// All detected update entries, including npm workspace members.
+    pub hits: Vec<EcosystemHit>,
+    /// Positive npm workspace member globs in Dependabot dir form ("/apps/*"),
+    /// from root pnpm-workspace.yaml `packages:` and package.json `workspaces`.
+    pub npm_workspace_globs: Vec<String>,
+    /// Negated ("!...") member globs excluded from membership.
+    pub npm_workspace_negations: Vec<String>,
+}
+
+impl EcosystemScan {
+    /// True if `dir` is an npm workspace member directory (not the root).
+    fn is_npm_workspace_member(&self, dir: &str) -> bool {
+        dir != "/"
+            && self.npm_workspace_globs.iter().any(|g| dir_matches(g, dir))
+            && !self
+                .npm_workspace_negations
+                .iter()
+                .any(|g| dir_matches(g, dir))
+    }
+
+    /// Hits suitable for generating a dependabot.yml: npm workspace member
+    /// directories are dropped because the root entry covers them.
+    pub fn config_hits(&self) -> Vec<EcosystemHit> {
+        self.hits
+            .iter()
+            .filter(|h| !(h.ecosystem == "npm" && self.is_npm_workspace_member(&h.directory)))
+            .cloned()
+            .collect()
+    }
+}
+
 /// Map a manifest filename to its Dependabot ecosystem.
 fn ecosystem_for_file(name: &str) -> Option<&'static str> {
     match name {
@@ -75,9 +111,10 @@ fn to_dependabot_dir(rel: &Path) -> String {
     }
 }
 
-/// Scan `root` for package manifests and return deduplicated Dependabot update entries,
-/// sorted by directory then ecosystem. Respects `.gitignore`.
-pub fn detect_ecosystems(root: &Path) -> Vec<EcosystemHit> {
+/// Scan `root` for package manifests and return deduplicated Dependabot update
+/// entries (sorted by directory then ecosystem) plus npm workspace layout.
+/// Respects `.gitignore`.
+pub fn detect_ecosystems(root: &Path) -> EcosystemScan {
     let mut hits: BTreeSet<EcosystemHit> = BTreeSet::new();
     // Terraform/OpenTofu share file layout (.tf, .terraform.lock.hcl) but are
     // separate Dependabot ecosystems — collect dirs first, decide after the walk.
@@ -198,15 +235,19 @@ pub fn detect_ecosystems(root: &Path) -> Vec<EcosystemHit> {
         .collect();
     hits.retain(|h| !(h.ecosystem == "pip" && uv_dirs.contains(&h.directory)));
 
-    // Workspace roots cover nested members: one entry at "/" is enough
+    // Cargo workspace roots cover nested members: one entry at "/" is enough.
+    // npm workspace members stay in `hits` (so missing coverage can name
+    // them); config generation collapses them via `config_hits()`.
     if cargo_workspace_at_root(root) {
         hits.retain(|h| h.ecosystem != "cargo" || h.directory == "/");
     }
-    if npm_workspace_at_root(root) {
-        hits.retain(|h| h.ecosystem != "npm" || h.directory == "/");
-    }
+    let (npm_workspace_globs, npm_workspace_negations) = npm_workspace_globs(root);
 
-    hits
+    EcosystemScan {
+        hits,
+        npm_workspace_globs,
+        npm_workspace_negations,
+    }
 }
 
 /// True if root `Cargo.toml` declares a `[workspace]`.
@@ -219,16 +260,48 @@ fn cargo_workspace_at_root(root: &Path) -> bool {
         .unwrap_or(false)
 }
 
-/// True if root `package.json` declares npm/yarn workspaces, or `pnpm-workspace.yaml` exists.
-fn npm_workspace_at_root(root: &Path) -> bool {
-    if root.join("pnpm-workspace.yaml").exists() {
-        return true;
+/// npm workspace member globs at `root`, as (positive, negated) lists in
+/// Dependabot dir form. Sources: pnpm-workspace.yaml `packages:` and root
+/// package.json `workspaces` (both the array and `{"packages": [...]}` forms).
+fn npm_workspace_globs(root: &Path) -> (Vec<String>, Vec<String>) {
+    let mut positive = Vec::new();
+    let mut negated = Vec::new();
+    let mut push = |glob: &str| {
+        if let Some(rest) = glob.strip_prefix('!') {
+            negated.push(normalize_dir(rest));
+        } else {
+            positive.push(normalize_dir(glob));
+        }
+    };
+
+    if let Ok(text) = std::fs::read_to_string(root.join("pnpm-workspace.yaml")) {
+        if let Ok(yaml) = serde_yaml::from_str::<serde_yaml::Value>(&text) {
+            for glob in yaml
+                .get("packages")
+                .and_then(|v| v.as_sequence())
+                .into_iter()
+                .flatten()
+                .filter_map(|v| v.as_str())
+            {
+                push(glob);
+            }
+        }
     }
-    std::fs::read_to_string(root.join("package.json"))
-        .ok()
-        .and_then(|s| serde_json::from_str::<serde_json::Value>(&s).ok())
-        .map(|v| v.get("workspaces").is_some())
-        .unwrap_or(false)
+
+    if let Ok(text) = std::fs::read_to_string(root.join("package.json")) {
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+            let ws = json.get("workspaces");
+            let globs = ws.and_then(|w| w.as_array()).or_else(|| {
+                ws.and_then(|w| w.get("packages"))
+                    .and_then(|p| p.as_array())
+            });
+            for glob in globs.into_iter().flatten().filter_map(|v| v.as_str()) {
+                push(glob);
+            }
+        }
+    }
+
+    (positive, negated)
 }
 
 /// Locate `.github/dependabot.yml` (or `.yaml`) under `root`.
@@ -317,25 +390,31 @@ fn dir_matches(pattern: &str, dir: &str) -> bool {
 }
 
 /// Return detected hits that have no matching `updates:` entry in the config.
-/// An unparseable config is treated as covering everything — GitHub itself
-/// reports invalid dependabot.yml files, so no extra warning is needed.
-pub fn uncovered_hits(config_text: &str, hits: &[EcosystemHit]) -> Vec<EcosystemHit> {
+/// An npm entry for the workspace root ("/") also covers workspace member
+/// directories. An unparseable config is treated as covering everything —
+/// GitHub itself reports invalid dependabot.yml files, so no extra warning is
+/// needed.
+pub fn uncovered_hits(config_text: &str, scan: &EcosystemScan) -> Vec<EcosystemHit> {
     let config: DependabotConfig = match serde_yaml::from_str(config_text) {
         Ok(c) => c,
         Err(_) => return Vec::new(),
     };
 
-    hits.iter()
+    scan.hits
+        .iter()
         .filter(|hit| {
+            let covers = |pattern: &str| {
+                dir_matches(pattern, &hit.directory)
+                    || (hit.ecosystem == "npm"
+                        && scan.is_npm_workspace_member(&hit.directory)
+                        && dir_matches(pattern, "/"))
+            };
             !config.updates.iter().any(|u| {
                 if u.package_ecosystem.as_deref() != Some(hit.ecosystem.as_str()) {
                     return false;
                 }
-                u.directory
-                    .as_deref()
-                    .map(|d| dir_matches(d, &hit.directory))
-                    .unwrap_or(false)
-                    || u.directories.iter().any(|d| dir_matches(d, &hit.directory))
+                u.directory.as_deref().map(covers).unwrap_or(false)
+                    || u.directories.iter().any(|d| covers(d))
             })
         })
         .cloned()
@@ -444,7 +523,7 @@ mod tests {
         write(root, "services/web/package.json", "{}");
         write(root, ".github/workflows/ci.yml", "name: ci\n");
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         assert!(hits.contains(&EcosystemHit {
             ecosystem: "cargo".into(),
             directory: "/".into()
@@ -478,7 +557,7 @@ mod tests {
         );
         write(root, "crates/a/Cargo.toml", "[package]\nname = \"a\"\n");
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         let cargo: Vec<_> = hits.iter().filter(|h| h.ecosystem == "cargo").collect();
         assert_eq!(cargo.len(), 1);
         assert_eq!(cargo[0].directory, "/");
@@ -492,7 +571,7 @@ mod tests {
         write(root, "infra/envs/prod/.terraform.lock.hcl", "");
         write(root, "infra/modules/net/main.tf", "");
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         let tf: Vec<_> = hits.iter().filter(|h| h.ecosystem == "terraform").collect();
         assert_eq!(tf.len(), 1);
         assert_eq!(tf[0].directory, "/infra/envs/prod");
@@ -504,7 +583,7 @@ mod tests {
         let root = tmp.path();
         write(root, "infra/main.tf", "");
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         assert!(hits.iter().any(|h| h.ecosystem == "terraform"));
     }
 
@@ -519,7 +598,7 @@ mod tests {
             "provider \"registry.opentofu.org/hashicorp/aws\" {\n  version = \"5.0.0\"\n}\n",
         );
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         assert!(hits.contains(&EcosystemHit {
             ecosystem: "opentofu".into(),
             directory: "/infra/prod".into()
@@ -533,7 +612,7 @@ mod tests {
         let root = tmp.path();
         write(root, "infra/opentofu/main.tf", "");
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         assert!(hits.contains(&EcosystemHit {
             ecosystem: "opentofu".into(),
             directory: "/infra/opentofu".into()
@@ -547,7 +626,7 @@ mod tests {
         let root = tmp.path();
         write(root, "infra/main.tofu", "");
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         assert!(hits.contains(&EcosystemHit {
             ecosystem: "opentofu".into(),
             directory: "/infra".into()
@@ -558,7 +637,7 @@ mod tests {
         write(root2, "envs/dev/main.tf", "");
         write(root2, "envs/dev/.opentofu-version", "1.8.0\n");
 
-        let hits2 = detect_ecosystems(root2);
+        let hits2 = detect_ecosystems(root2).hits;
         assert!(hits2.contains(&EcosystemHit {
             ecosystem: "opentofu".into(),
             directory: "/envs/dev".into()
@@ -576,7 +655,7 @@ mod tests {
             "provider \"registry.terraform.io/hashicorp/aws\" {\n  version = \"5.0.0\"\n}\n",
         );
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         assert!(hits.contains(&EcosystemHit {
             ecosystem: "terraform".into(),
             directory: "/infra/prod".into()
@@ -591,7 +670,7 @@ mod tests {
         write(root, "tool/pyproject.toml", "");
         write(root, "tool/uv.lock", "");
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         assert!(hits.iter().any(|h| h.ecosystem == "uv"));
         assert!(!hits.iter().any(|h| h.ecosystem == "pip"));
     }
@@ -604,14 +683,21 @@ mod tests {
         write(root, "vendor/pkg/package.json", "{}");
         write(root, "go.mod", "module x\n");
 
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         assert!(!hits.iter().any(|h| h.ecosystem == "npm"));
         assert!(hits.iter().any(|h| h.ecosystem == "gomod"));
     }
 
+    fn scan_of(hits: Vec<EcosystemHit>) -> EcosystemScan {
+        EcosystemScan {
+            hits,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn test_uncovered_hits() {
-        let hits = vec![
+        let scan = scan_of(vec![
             EcosystemHit {
                 ecosystem: "cargo".into(),
                 directory: "/".into(),
@@ -620,16 +706,16 @@ mod tests {
                 ecosystem: "mix".into(),
                 directory: "/services/api".into(),
             },
-        ];
+        ]);
         let config = "version: 2\nupdates:\n  - package-ecosystem: cargo\n    directory: /\n    schedule:\n      interval: weekly\n";
-        let missing = uncovered_hits(config, &hits);
+        let missing = uncovered_hits(config, &scan);
         assert_eq!(missing.len(), 1);
         assert_eq!(missing[0].ecosystem, "mix");
     }
 
     #[test]
     fn test_uncovered_hits_directories_glob() {
-        let hits = vec![
+        let scan = scan_of(vec![
             EcosystemHit {
                 ecosystem: "mix".into(),
                 directory: "/services/api".into(),
@@ -638,30 +724,113 @@ mod tests {
                 ecosystem: "npm".into(),
                 directory: "/services/web".into(),
             },
-        ];
+        ]);
         let config = "version: 2\nupdates:\n  - package-ecosystem: mix\n    directories:\n      - \"/services/*\"\n  - package-ecosystem: npm\n    directory: \"/services/*\"\n";
-        assert!(uncovered_hits(config, &hits).is_empty());
+        assert!(uncovered_hits(config, &scan).is_empty());
     }
 
     #[test]
     fn test_uncovered_hits_invalid_yaml_covers_all() {
-        let hits = vec![EcosystemHit {
+        let scan = scan_of(vec![EcosystemHit {
             ecosystem: "cargo".into(),
             directory: "/".into(),
-        }];
-        assert!(uncovered_hits(": not yaml [", &hits).is_empty());
+        }]);
+        assert!(uncovered_hits(": not yaml [", &scan).is_empty());
     }
 
     #[test]
     fn test_generate_config() {
-        let hits = vec![EcosystemHit {
+        let scan = scan_of(vec![EcosystemHit {
             ecosystem: "cargo".into(),
             directory: "/".into(),
-        }];
-        let yaml = generate_config(&hits);
+        }]);
+        let yaml = generate_config(&scan.hits);
         assert!(yaml.starts_with("version: 2\n"));
         // Round-trip: generated config covers all hits
-        assert!(uncovered_hits(&yaml, &hits).is_empty());
+        assert!(uncovered_hits(&yaml, &scan).is_empty());
+    }
+
+    /// A pnpm monorepo: workspace with member apps, plus a standalone npm
+    /// service that is NOT a workspace member.
+    #[test]
+    fn test_npm_workspace_members_reported_and_covered_by_root() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(root, "package.json", "{}");
+        write(root, "pnpm-lock.yaml", "");
+        write(
+            root,
+            "pnpm-workspace.yaml",
+            "packages:\n  - apps/*\n  - packages/*\n",
+        );
+        write(root, "apps/board/package.json", "{}");
+        write(root, "apps/web/package.json", "{}");
+        write(root, "services/marketing/package.json", "{}");
+        write(root, "services/marketing/package-lock.json", "{}");
+
+        let scan = detect_ecosystems(root);
+        for dir in ["/", "/apps/board", "/apps/web", "/services/marketing"] {
+            assert!(
+                scan.hits
+                    .iter()
+                    .any(|h| h.ecosystem == "npm" && h.directory == dir),
+                "expected npm hit for {dir}: {:?}",
+                scan.hits
+            );
+        }
+
+        // No npm entry at all → every npm dir is uncovered.
+        let missing = uncovered_hits("version: 2\nupdates: []\n", &scan);
+        let npm_dirs: Vec<&str> = missing
+            .iter()
+            .filter(|h| h.ecosystem == "npm")
+            .map(|h| h.directory.as_str())
+            .collect();
+        assert_eq!(
+            npm_dirs,
+            vec!["/", "/apps/board", "/apps/web", "/services/marketing"]
+        );
+
+        // Root npm entry covers the workspace members but not the
+        // standalone service.
+        let config = "version: 2\nupdates:\n  - package-ecosystem: npm\n    directory: /\n";
+        let missing = uncovered_hits(config, &scan);
+        let npm_dirs: Vec<&str> = missing
+            .iter()
+            .filter(|h| h.ecosystem == "npm")
+            .map(|h| h.directory.as_str())
+            .collect();
+        assert_eq!(npm_dirs, vec!["/services/marketing"]);
+
+        // Config generation collapses members but keeps the standalone dir.
+        let config_dirs: Vec<String> = scan
+            .config_hits()
+            .into_iter()
+            .filter(|h| h.ecosystem == "npm")
+            .map(|h| h.directory)
+            .collect();
+        assert_eq!(config_dirs, vec!["/", "/services/marketing"]);
+        assert!(uncovered_hits(&generate_config(&scan.config_hits()), &scan).is_empty());
+    }
+
+    #[test]
+    fn test_npm_workspace_negated_glob_excludes_member() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+        write(
+            root,
+            "package.json",
+            r#"{"workspaces": {"packages": ["apps/*", "!apps/legacy"]}}"#,
+        );
+        write(root, "apps/board/package.json", "{}");
+        write(root, "apps/legacy/package.json", "{}");
+
+        let scan = detect_ecosystems(root);
+        let config = "version: 2\nupdates:\n  - package-ecosystem: npm\n    directory: /\n";
+        let missing = uncovered_hits(config, &scan);
+        let npm_dirs: Vec<&str> = missing.iter().map(|h| h.directory.as_str()).collect();
+        // Excluded member is not covered by the root entry.
+        assert_eq!(npm_dirs, vec!["/apps/legacy"]);
     }
 
     #[test]
@@ -678,7 +847,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let root = tmp.path();
         write(root, "flake.nix", "{ }\n");
-        let hits = detect_ecosystems(root);
+        let hits = detect_ecosystems(root).hits;
         assert!(hits.contains(&EcosystemHit {
             ecosystem: "nix".into(),
             directory: "/".into()

--- a/crates/md-db/src/devenv.rs
+++ b/crates/md-db/src/devenv.rs
@@ -1,0 +1,274 @@
+//! Start devenv-managed services (postgres, redis, …) for the duration of
+//! service checks, so test suites on a fresh clone find their backing
+//! services running. Uses the devenv 2.x process manager: `devenv up -d`,
+//! `devenv processes wait`, `devenv down`.
+
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use crate::progress::ProgressSink;
+use crate::toolchain::run_with_timeout;
+
+const LIST_TIMEOUT: Duration = Duration::from_secs(60);
+/// First `devenv up` may build the environment.
+const UP_TIMEOUT: Duration = Duration::from_secs(600);
+const WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+const DOWN_TIMEOUT: Duration = Duration::from_secs(60);
+
+static SERVICE_NAME_RE: LazyLock<Option<regex::Regex>> =
+    LazyLock::new(|| regex::Regex::new(r"services\.([A-Za-z0-9_-]+)").ok());
+static SERVICE_ATTRSET_RE: LazyLock<Option<regex::Regex>> =
+    LazyLock::new(|| regex::Regex::new(r"services\s*=\s*\{").ok());
+
+/// Service names declared in `root/devenv.nix`, or `None` when the file is
+/// missing or declares no services. Detects both the dotted form
+/// (`services.postgres.enable = true;`) and the attribute-set form
+/// (`services = { postgres = …; };` — names not extracted). Services pulled
+/// in via `imports` or devenv.yaml profiles are not detected (v1 limitation).
+pub fn declared_services(root: &Path) -> Option<Vec<String>> {
+    let text = std::fs::read_to_string(root.join("devenv.nix")).ok()?;
+    let mut names: Vec<String> = Vec::new();
+    if let Some(re) = SERVICE_NAME_RE.as_ref() {
+        for cap in re.captures_iter(&text) {
+            let name = cap[1].to_string();
+            if !names.contains(&name) {
+                names.push(name);
+            }
+        }
+    }
+    let attrset = SERVICE_ATTRSET_RE
+        .as_ref()
+        .map(|re| re.is_match(&text))
+        .unwrap_or(false);
+    if names.is_empty() && !attrset {
+        return None;
+    }
+    Some(names)
+}
+
+/// Stops services on drop when this run started them (never when they were
+/// already running before dg).
+pub struct DevenvGuard {
+    root: PathBuf,
+    path: OsString,
+}
+
+impl Drop for DevenvGuard {
+    fn drop(&mut self) {
+        let mut cmd = devenv_command(&self.root, &self.path);
+        cmd.arg("down");
+        let _ = run_with_timeout(&mut cmd, DOWN_TIMEOUT);
+    }
+}
+
+/// Result of ensuring devenv services are up.
+pub enum StartOutcome {
+    /// dg started the services; drop the guard to stop them again.
+    Started(DevenvGuard),
+    /// Services were already running — leave them alone.
+    AlreadyRunning,
+    /// Starting failed; checks proceed but dependent tests may fail.
+    Failed {
+        /// Tail of the failing `devenv up -d` output, for the diagnostic hint.
+        output_tail: String,
+    },
+}
+
+fn devenv_command(root: &Path, path: &OsStr) -> Command {
+    let mut cmd = Command::new("devenv");
+    cmd.current_dir(root);
+    // Explicit PATH also controls binary lookup for the child (documented
+    // std::process behavior), which keeps this testable with stub binaries.
+    cmd.env("PATH", path);
+    cmd.env("NO_COLOR", "1");
+    cmd
+}
+
+/// Ensure devenv-managed services are running under `root`. Emits a progress
+/// notice before actually starting anything.
+pub fn start_services(
+    root: &Path,
+    path: &OsStr,
+    service_names: &[String],
+    sink: Option<&dyn ProgressSink>,
+) -> StartOutcome {
+    // Already running? `devenv processes list` succeeds with process rows
+    // when the process manager is up.
+    let mut list = devenv_command(root, path);
+    list.args(["processes", "list"]);
+    if let Ok(out) = run_with_timeout(&mut list, LIST_TIMEOUT) {
+        if out.success && !out.stdout.trim().is_empty() {
+            return StartOutcome::AlreadyRunning;
+        }
+    }
+
+    if let Some(sink) = sink {
+        let names = if service_names.is_empty() {
+            String::new()
+        } else {
+            format!(" ({})", service_names.join(", "))
+        };
+        sink.notice(&format!(
+            "starting devenv services{names} in {} for the duration of the checks",
+            root.display()
+        ));
+    }
+
+    let mut up = devenv_command(root, path);
+    up.args(["up", "-d"]);
+    match run_with_timeout(&mut up, UP_TIMEOUT) {
+        Ok(out) if out.success => {}
+        Ok(out) => {
+            // Belt and braces: a concurrent `devenv up` counts as running.
+            let combined = format!("{}\n{}", out.stdout, out.stderr).to_lowercase();
+            if combined.contains("already running") {
+                return StartOutcome::AlreadyRunning;
+            }
+            let mut tail = crate::toolchain::output_preview(&out.stdout, &out.stderr, 8)
+                .unwrap_or_else(|| "no output".to_string());
+            if out.timed_out {
+                tail = format!("timed out after {}s", UP_TIMEOUT.as_secs());
+            }
+            return StartOutcome::Failed { output_tail: tail };
+        }
+        Err(e) => {
+            return StartOutcome::Failed {
+                output_tail: format!("failed to run `devenv up -d`: {e}"),
+            }
+        }
+    }
+
+    let guard = DevenvGuard {
+        root: root.to_path_buf(),
+        path: path.to_os_string(),
+    };
+
+    // Best-effort readiness: services report ready via process-compose
+    // probes; a failure here still lets the checks run.
+    let mut wait = devenv_command(root, path);
+    wait.args(["processes", "wait"]);
+    let _ = run_with_timeout(&mut wait, WAIT_TIMEOUT);
+
+    StartOutcome::Started(guard)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn declared_services_detects_dotted_and_attrset() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(declared_services(tmp.path()).is_none());
+
+        fs::write(
+            tmp.path().join("devenv.nix"),
+            "{\n  services.postgres = {\n    enable = true;\n  };\n  services.redis.enable = true;\n}\n",
+        )
+        .unwrap();
+        assert_eq!(
+            declared_services(tmp.path()),
+            Some(vec!["postgres".to_string(), "redis".to_string()])
+        );
+
+        fs::write(
+            tmp.path().join("devenv.nix"),
+            "{\n  services = {\n    postgres.enable = true;\n  };\n}\n",
+        )
+        .unwrap();
+        assert_eq!(declared_services(tmp.path()), Some(vec![]));
+
+        fs::write(tmp.path().join("devenv.nix"), "{ packages = [ ]; }\n").unwrap();
+        assert!(declared_services(tmp.path()).is_none());
+    }
+
+    #[cfg(unix)]
+    fn make_stub(bin_dir: &Path, name: &str, script: &str) {
+        use std::os::unix::fs::PermissionsExt;
+        fs::create_dir_all(bin_dir).unwrap();
+        let path = bin_dir.join(name);
+        fs::write(&path, script).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn start_services_runs_up_wait_and_down_on_drop() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        let marker = tmp.path().join("marker");
+        // `processes list` fails (nothing running); everything else succeeds.
+        make_stub(
+            &bin,
+            "devenv",
+            &format!(
+                "#!/bin/sh\necho \"$@\" >> {m}\ncase \"$1\" in\n  processes) [ \"$2\" = list ] && exit 1 || exit 0;;\n  *) exit 0;;\nesac\n",
+                m = marker.display()
+            ),
+        );
+        let path = bin.into_os_string();
+
+        let outcome = start_services(tmp.path(), &path, &[], None);
+        let guard = match outcome {
+            StartOutcome::Started(g) => g,
+            StartOutcome::AlreadyRunning => panic!("expected Started, got AlreadyRunning"),
+            StartOutcome::Failed { output_tail } => panic!("expected Started: {output_tail}"),
+        };
+        drop(guard);
+
+        let calls = fs::read_to_string(&marker).unwrap();
+        let calls: Vec<&str> = calls.lines().collect();
+        assert_eq!(
+            calls,
+            vec!["processes list", "up -d", "processes wait", "down"]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn start_services_leaves_running_services_alone() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        let marker = tmp.path().join("marker");
+        make_stub(
+            &bin,
+            "devenv",
+            &format!(
+                "#!/bin/sh\necho \"$@\" >> {m}\nif [ \"$1\" = processes ] && [ \"$2\" = list ]; then echo 'postgres  Running'; exit 0; fi\nexit 0\n",
+                m = marker.display()
+            ),
+        );
+        let path = bin.into_os_string();
+
+        assert!(matches!(
+            start_services(tmp.path(), &path, &[], None),
+            StartOutcome::AlreadyRunning
+        ));
+        let calls = fs::read_to_string(&marker).unwrap();
+        assert_eq!(calls.lines().collect::<Vec<_>>(), vec!["processes list"]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn start_services_reports_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        make_stub(
+            &bin,
+            "devenv",
+            "#!/bin/sh\nif [ \"$1\" = up ]; then echo 'evaluation aborted' >&2; exit 1; fi\nexit 1\n",
+        );
+        let path = bin.into_os_string();
+
+        match start_services(tmp.path(), &path, &[], None) {
+            StartOutcome::Failed { output_tail } => {
+                assert!(output_tail.contains("evaluation aborted"), "{output_tail}");
+            }
+            _ => panic!("expected Failed"),
+        }
+    }
+}

--- a/crates/md-db/src/lib.rs
+++ b/crates/md-db/src/lib.rs
@@ -15,6 +15,8 @@ pub mod cache;
 pub mod coverage;
 /// Dependabot ecosystem detection and coverage checks.
 pub mod dependabot;
+/// Start/stop devenv-managed services around service checks.
+pub mod devenv;
 /// Structural diff between two document versions.
 #[allow(missing_docs)]
 pub mod diff;

--- a/crates/md-db/src/toolchain.rs
+++ b/crates/md-db/src/toolchain.rs
@@ -40,6 +40,17 @@ impl PackageManager {
         }
     }
 
+    /// True when this package manager's install executes dependency
+    /// lifecycle scripts by default (arbitrary code from the registry).
+    /// pnpm and bun block untrusted build/postinstall scripts by default,
+    /// so their installs are safe to run unattended.
+    pub fn runs_install_scripts(&self) -> bool {
+        matches!(
+            self,
+            PackageManager::Npm | PackageManager::Yarn | PackageManager::YarnBerry
+        )
+    }
+
     /// Program + prefix args for executing a locally-installed tool
     /// (e.g. `pnpm exec vitest run`, `bunx vitest run`).
     pub fn exec_prefix(&self) -> (&'static str, &'static [&'static str]) {
@@ -198,6 +209,33 @@ pub fn js_deps_present(workspace_root: &Path) -> bool {
         || workspace_root.join(".pnp.data.json").is_file()
 }
 
+/// True if an Elixir mix project's dependencies look fetched.
+pub fn mix_deps_present(service_dir: &Path) -> bool {
+    service_dir.join("deps").is_dir()
+}
+
+/// Package names with unresolved `allowBuilds:` entries in the workspace
+/// root's pnpm-workspace.yaml. pnpm scaffolds placeholder values ("set this
+/// to true or false") when an install hits ERR_PNPM_IGNORED_BUILDS; until a
+/// human decides (`pnpm approve-builds` or editing the file), build scripts
+/// stay skipped on every install.
+pub fn pnpm_unapproved_builds(workspace_root: &Path) -> Vec<String> {
+    let Ok(text) = std::fs::read_to_string(workspace_root.join("pnpm-workspace.yaml")) else {
+        return Vec::new();
+    };
+    let Ok(yaml) = serde_yaml::from_str::<serde_yaml::Value>(&text) else {
+        return Vec::new();
+    };
+    let Some(allow) = yaml.get("allowBuilds").and_then(|v| v.as_mapping()) else {
+        return Vec::new();
+    };
+    allow
+        .iter()
+        .filter(|(_, v)| !v.is_bool())
+        .filter_map(|(k, _)| k.as_str().map(String::from))
+        .collect()
+}
+
 /// Dev-environment wrapper that can provide missing binaries.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EnvWrapperKind {
@@ -278,7 +316,7 @@ fn detect_env_wrapper_with_path(
 }
 
 /// Check if an executable named `name` exists on the given PATH value.
-fn binary_on_path(name: &str, path: &OsStr) -> bool {
+pub(crate) fn binary_on_path(name: &str, path: &OsStr) -> bool {
     std::env::split_paths(path).any(|dir| {
         let candidate = dir.join(name);
         is_executable(&candidate)
@@ -304,8 +342,16 @@ fn is_executable(path: &Path) -> bool {
 pub enum InstallOutcome {
     AlreadyInstalled,
     Installed,
+    /// pnpm materialized node_modules but exited non-zero because dependency
+    /// build scripts are unapproved (ERR_PNPM_IGNORED_BUILDS with
+    /// strictDepBuilds on). Dependencies are usable; approval is a repo
+    /// hygiene concern surfaced separately.
+    InstalledIgnoredBuilds,
     /// `--no-install` was given and node_modules is missing.
     SkippedNoInstall,
+    /// Install would run dependency lifecycle scripts and no interactive
+    /// approval was available (or the user declined).
+    SkippedNeedsApproval,
     /// Package-manager binary not on PATH and no usable env wrapper.
     SkippedNoPm {
         pm_binary: &'static str,
@@ -318,14 +364,22 @@ pub enum InstallOutcome {
 
 const INSTALL_TIMEOUT: Duration = Duration::from_secs(600);
 
+/// Interactive yes/no confirmation callback (message → approved?).
+pub type ConfirmFn = std::sync::Arc<dyn Fn(&str) -> bool + Send + Sync>;
+
 /// Per-validate-run toolchain state: env wrapper (detected once) and install
 /// outcomes cached per workspace root, so a monorepo installs only once.
 pub struct ToolchainContext {
     wrapper: Option<EnvWrapper>,
     env_files_found: Vec<&'static str>,
     installs: HashMap<PathBuf, InstallOutcome>,
+    // Separate from `installs`: a dir could hold both package.json and mix.exs.
+    mix_installs: HashMap<PathBuf, InstallOutcome>,
     no_install: bool,
     path: OsString,
+    /// Asks the user before installs that execute dependency scripts
+    /// (npm/yarn). `None` (non-interactive) means such installs are skipped.
+    confirm: Option<ConfirmFn>,
 }
 
 impl ToolchainContext {
@@ -341,8 +395,10 @@ impl ToolchainContext {
             wrapper,
             env_files_found,
             installs: HashMap::new(),
+            mix_installs: HashMap::new(),
             no_install,
             path,
+            confirm: None,
         }
     }
 
@@ -352,6 +408,16 @@ impl ToolchainContext {
 
     pub fn env_files_found(&self) -> &[&'static str] {
         &self.env_files_found
+    }
+
+    /// The PATH captured when this context was created.
+    pub(crate) fn path(&self) -> &OsStr {
+        &self.path
+    }
+
+    /// Set the interactive confirmation callback for script-running installs.
+    pub fn set_confirm(&mut self, confirm: ConfirmFn) {
+        self.confirm = Some(confirm);
     }
 
     /// Hint suffix when env config files exist but no wrapper binary is
@@ -413,6 +479,78 @@ impl ToolchainContext {
         outcome
     }
 
+    /// Ensure Elixir mix dependencies are fetched for a service directory,
+    /// running `mix deps.get` if needed. Cached per service directory.
+    pub fn ensure_mix_deps(&mut self, service_dir: &Path) -> InstallOutcome {
+        if let Some(outcome) = self.mix_installs.get(service_dir) {
+            return outcome.clone();
+        }
+        let outcome = self.install_mix_deps(service_dir);
+        self.mix_installs
+            .insert(service_dir.to_path_buf(), outcome.clone());
+        outcome
+    }
+
+    fn install_mix_deps(&self, service_dir: &Path) -> InstallOutcome {
+        if mix_deps_present(service_dir) {
+            return InstallOutcome::AlreadyInstalled;
+        }
+        if self.no_install {
+            return InstallOutcome::SkippedNoInstall;
+        }
+        if !binary_on_path("mix", &self.path) && self.wrapper.is_none() {
+            return InstallOutcome::SkippedNoPm { pm_binary: "mix" };
+        }
+        let (program, args) = self.finalize("mix", vec!["deps.get".into()]);
+
+        let mut command = Command::new(&program);
+        command.args(&args);
+        command.current_dir(service_dir);
+        command.env("NO_COLOR", "1");
+        command.env("CI", "1");
+        command.env("PATH", &self.path);
+
+        match run_with_timeout(&mut command, INSTALL_TIMEOUT) {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                InstallOutcome::SkippedNoPm { pm_binary: "mix" }
+            }
+            Err(e) => InstallOutcome::Failed {
+                exit_code: None,
+                output_tail: format!("failed to run `{program}`: {e}"),
+            },
+            Ok(output) if output.success => InstallOutcome::Installed,
+            Ok(output) => {
+                let mut tail = output_preview(&output.stdout, &output.stderr, 5)
+                    .unwrap_or_else(|| "no output".to_string());
+                if output.timed_out {
+                    tail = format!("timed out after {}s", INSTALL_TIMEOUT.as_secs());
+                }
+                InstallOutcome::Failed {
+                    exit_code: output.exit_code,
+                    output_tail: tail,
+                }
+            }
+        }
+    }
+
+    /// Run pnpm's interactive build-approval picker with inherited stdio, so
+    /// the user decides which dependency build scripts may run. Returns true
+    /// when the command completed successfully. Only call when a TTY is
+    /// available.
+    pub fn run_pnpm_approve_builds(&self, workspace_root: &Path) -> bool {
+        let (program, args) = self.finalize("pnpm", vec!["approve-builds".into()]);
+        Command::new(&program)
+            .args(&args)
+            .current_dir(workspace_root)
+            .env("PATH", &self.path)
+            .stdin(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::inherit())
+            .stderr(std::process::Stdio::inherit())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false)
+    }
+
     fn install_js_deps(&self, js: &JsToolchain) -> InstallOutcome {
         if js_deps_present(&js.workspace_root) {
             return InstallOutcome::AlreadyInstalled;
@@ -427,6 +565,23 @@ impl ToolchainContext {
             };
         }
         let args: Vec<String> = args.into_iter().map(String::from).collect();
+        // npm/yarn installs execute dependency lifecycle scripts — only run
+        // them with explicit interactive approval. pnpm/bun block untrusted
+        // scripts by default and stay fully automatic.
+        if js.pm.runs_install_scripts() {
+            let install_cmd = std::iter::once(program.to_string())
+                .chain(args.iter().cloned())
+                .collect::<Vec<_>>()
+                .join(" ");
+            let prompt = format!(
+                "`{install_cmd}` in {} may run dependency install scripts — run it now?",
+                js.workspace_root.display()
+            );
+            match &self.confirm {
+                Some(confirm) if confirm(&prompt) => {}
+                _ => return InstallOutcome::SkippedNeedsApproval,
+            }
+        }
         let (program, args) = self.finalize(program, args);
 
         let mut command = Command::new(&program);
@@ -446,6 +601,17 @@ impl ToolchainContext {
             },
             Ok(output) if output.success => InstallOutcome::Installed,
             Ok(output) => {
+                // pnpm (strictDepBuilds default) fails AFTER writing
+                // node_modules when build scripts are unapproved — deps are
+                // complete and usable.
+                if js.pm == PackageManager::Pnpm
+                    && !output.timed_out
+                    && (output.stdout.contains("ERR_PNPM_IGNORED_BUILDS")
+                        || output.stderr.contains("ERR_PNPM_IGNORED_BUILDS"))
+                    && js_deps_present(&js.workspace_root)
+                {
+                    return InstallOutcome::InstalledIgnoredBuilds;
+                }
                 let mut tail = output_preview(&output.stdout, &output.stderr, 5)
                     .unwrap_or_else(|| "no output".to_string());
                 if output.timed_out {
@@ -889,6 +1055,55 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn pnpm_ignored_builds_with_node_modules_counts_as_installed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        // pnpm 11 with strictDepBuilds writes node_modules, then exits 1.
+        make_stub(
+            &bin,
+            "pnpm",
+            "#!/bin/sh\n/bin/mkdir -p node_modules\necho ' ERR_PNPM_IGNORED_BUILDS  Ignored build scripts: esbuild@0.27.7' >&2\nexit 1\n",
+        );
+        let js = js_fixture(tmp.path());
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, bin.into_os_string());
+        assert_eq!(
+            ctx.ensure_js_deps(&js),
+            InstallOutcome::InstalledIgnoredBuilds
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pnpm_ignored_builds_without_node_modules_stays_failed() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        make_stub(
+            &bin,
+            "pnpm",
+            "#!/bin/sh\necho ' ERR_PNPM_IGNORED_BUILDS ' >&2\nexit 1\n",
+        );
+        let js = js_fixture(tmp.path());
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, bin.into_os_string());
+        assert!(matches!(
+            ctx.ensure_js_deps(&js),
+            InstallOutcome::Failed { .. }
+        ));
+    }
+
+    #[test]
+    fn pnpm_unapproved_builds_finds_placeholders() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(pnpm_unapproved_builds(tmp.path()).is_empty());
+
+        write(
+            &tmp.path().join("pnpm-workspace.yaml"),
+            "packages:\n  - apps/*\nallowBuilds:\n  esbuild: set this to true or false\n  sharp: true\n  workerd: false\n",
+        );
+        assert_eq!(pnpm_unapproved_builds(tmp.path()), vec!["esbuild"]);
+    }
+
     #[test]
     fn ensure_js_deps_skips() {
         let tmp = tempfile::tempdir().unwrap();
@@ -907,6 +1122,124 @@ mod tests {
         fs::create_dir_all(tmp.path().join("node_modules")).unwrap();
         let mut ctx = ToolchainContext::with_path(tmp.path(), false, OsString::new());
         assert_eq!(ctx.ensure_js_deps(&js), InstallOutcome::AlreadyInstalled);
+    }
+
+    // --- script-running installs need approval ---
+
+    #[cfg(unix)]
+    #[test]
+    fn npm_install_gated_on_interactive_approval() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        let marker = tmp.path().join("marker");
+        make_stub(
+            &bin,
+            "npm",
+            &format!("#!/bin/sh\necho ran >> {}\nexit 0\n", marker.display()),
+        );
+        write(&tmp.path().join("package-lock.json"), "{}");
+        let js = detect_js_toolchain(tmp.path(), tmp.path());
+        assert_eq!(js.pm, PackageManager::Npm);
+
+        // Non-interactive (no confirm callback): skipped, npm never runs.
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, bin.clone().into_os_string());
+        assert_eq!(
+            ctx.ensure_js_deps(&js),
+            InstallOutcome::SkippedNeedsApproval
+        );
+        assert!(!marker.exists());
+
+        // Declined: skipped.
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, bin.clone().into_os_string());
+        ctx.set_confirm(std::sync::Arc::new(|_: &str| false));
+        assert_eq!(
+            ctx.ensure_js_deps(&js),
+            InstallOutcome::SkippedNeedsApproval
+        );
+        assert!(!marker.exists());
+
+        // Approved: installs.
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, bin.into_os_string());
+        ctx.set_confirm(std::sync::Arc::new(|_: &str| true));
+        assert_eq!(ctx.ensure_js_deps(&js), InstallOutcome::Installed);
+        assert!(marker.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pnpm_install_needs_no_approval() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        make_stub(&bin, "pnpm", "#!/bin/sh\nexit 0\n");
+        let js = js_fixture(tmp.path());
+        // No confirm callback set — pnpm blocks untrusted scripts itself.
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, bin.into_os_string());
+        assert_eq!(ctx.ensure_js_deps(&js), InstallOutcome::Installed);
+    }
+
+    // --- mix deps ---
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_mix_deps_installs_and_caches() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        let marker = tmp.path().join("marker");
+        make_stub(
+            &bin,
+            "mix",
+            &format!("#!/bin/sh\necho ran >> {}\nexit 0\n", marker.display()),
+        );
+        write(&tmp.path().join("mix.exs"), "");
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, bin.into_os_string());
+
+        assert_eq!(ctx.ensure_mix_deps(tmp.path()), InstallOutcome::Installed);
+        assert_eq!(ctx.ensure_mix_deps(tmp.path()), InstallOutcome::Installed);
+        let runs = fs::read_to_string(&marker).unwrap();
+        assert_eq!(runs.lines().count(), 1, "deps.get must run once (cached)");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_mix_deps_failure() {
+        let tmp = tempfile::tempdir().unwrap();
+        let bin = tmp.path().join("bin");
+        make_stub(
+            &bin,
+            "mix",
+            "#!/bin/sh\necho 'could not fetch' >&2\nexit 1\n",
+        );
+        write(&tmp.path().join("mix.exs"), "");
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, bin.into_os_string());
+        match ctx.ensure_mix_deps(tmp.path()) {
+            InstallOutcome::Failed { exit_code, .. } => assert_eq!(exit_code, Some(1)),
+            other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ensure_mix_deps_skips() {
+        let tmp = tempfile::tempdir().unwrap();
+        write(&tmp.path().join("mix.exs"), "");
+
+        let mut ctx = ToolchainContext::with_path(tmp.path(), true, OsString::new());
+        assert_eq!(
+            ctx.ensure_mix_deps(tmp.path()),
+            InstallOutcome::SkippedNoInstall
+        );
+
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, OsString::new());
+        assert_eq!(
+            ctx.ensure_mix_deps(tmp.path()),
+            InstallOutcome::SkippedNoPm { pm_binary: "mix" }
+        );
+
+        fs::create_dir_all(tmp.path().join("deps")).unwrap();
+        let mut ctx = ToolchainContext::with_path(tmp.path(), false, OsString::new());
+        assert_eq!(
+            ctx.ensure_mix_deps(tmp.path()),
+            InstallOutcome::AlreadyInstalled
+        );
     }
 
     // --- output preview ---

--- a/crates/md-db/src/validation/directory.rs
+++ b/crates/md-db/src/validation/directory.rs
@@ -360,12 +360,18 @@ pub(crate) fn dependabot_diagnostics(dir: &Path, file_results: &mut Vec<FileResu
         return;
     }
 
-    let hits = db::detect_ecosystems(dir);
-    if !hits.is_empty() {
+    let scan = db::detect_ecosystems(dir);
+    if !scan.hits.is_empty() {
         let config_path = db::find_config(dir);
-        let labels = hits.iter().map(db::EcosystemHit::label).collect::<Vec<_>>();
         match config_path {
             None => {
+                // Workspace members are covered by the root entry the hint
+                // proposes, so count/list only config-worthy hits here.
+                let config_hits = scan.config_hits();
+                let labels = config_hits
+                    .iter()
+                    .map(db::EcosystemHit::label)
+                    .collect::<Vec<_>>();
                 file_results.push(FileResult {
                     path: dir.join(".github/dependabot.yml").display().to_string(),
                     diagnostics: vec![Diagnostic {
@@ -373,7 +379,7 @@ pub(crate) fn dependabot_diagnostics(dir: &Path, file_results: &mut Vec<FileResu
                         code: "SV011".into(),
                         message: format!(
                             "GitHub-hosted project has no .github/dependabot.yml but {} package ecosystem(s) were detected",
-                            hits.len()
+                            config_hits.len()
                         ),
                         location: ".github/dependabot.yml".into(),
                         hint: Some(format!(
@@ -385,7 +391,7 @@ pub(crate) fn dependabot_diagnostics(dir: &Path, file_results: &mut Vec<FileResu
             }
             Some(path) => {
                 if let Ok(text) = std::fs::read_to_string(&path) {
-                    let missing = db::uncovered_hits(&text, &hits);
+                    let missing = db::uncovered_hits(&text, &scan);
                     if !missing.is_empty() {
                         let missing_labels = missing
                             .iter()
@@ -444,6 +450,9 @@ pub struct ServiceCheckOptions {
     pub no_install: bool,
     /// Receiver for progress events; `None` runs silently.
     pub progress: Option<std::sync::Arc<dyn crate::progress::ProgressSink>>,
+    /// Interactive confirmation for installs that execute dependency scripts
+    /// (npm/yarn). `None` (non-interactive) skips those installs.
+    pub confirm: Option<crate::toolchain::ConfirmFn>,
 }
 
 impl std::fmt::Debug for ServiceCheckOptions {
@@ -451,6 +460,7 @@ impl std::fmt::Debug for ServiceCheckOptions {
         f.debug_struct("ServiceCheckOptions")
             .field("no_install", &self.no_install)
             .field("progress", &self.progress.is_some())
+            .field("confirm", &self.confirm.is_some())
             .finish()
     }
 }
@@ -497,12 +507,17 @@ struct ServicePlan {
 pub fn validate_service_checks(dir: &Path, opts: &ServiceCheckOptions) -> ServiceCheckOutcome {
     let mut results = Vec::new();
     let mut ctx = crate::toolchain::ToolchainContext::new(dir, opts.no_install);
+    if let Some(confirm) = &opts.confirm {
+        ctx.set_confirm(confirm.clone());
+    }
 
     let plans = plan_service_checks(dir);
 
     // Install JS deps serially, once per workspace root (cached in ctx) —
     // concurrent installs into one package store would race.
     let mut runnable = Vec::new();
+    let mut checked_pnpm_roots: HashSet<PathBuf> = HashSet::new();
+    let mut broken_pnpm_roots: HashSet<PathBuf> = HashSet::new();
     for plan in plans {
         if let Some(js) = &plan.js {
             if let Some(sink) = &opts.progress {
@@ -514,13 +529,81 @@ pub fn validate_service_checks(dir: &Path, opts: &ServiceCheckOptions) -> Servic
                     ));
                 }
             }
-            if let Some(diag) = ensure_js_deps_diagnostic(&mut ctx, js, &plan.location) {
+            let outcome = ctx.ensure_js_deps(js);
+            // Deps are usable but pnpm skipped build scripts pending approval.
+            // pnpm 11 also gates `pnpm exec` on this state, so unresolved
+            // roots skip their checks. The yaml check keeps this alive on
+            // reruns, where the install itself is skipped (node_modules
+            // already present). Interactive runs offer pnpm's own
+            // `approve-builds` picker — the user decides, dg never approves
+            // build scripts on its own.
+            let unapproved = crate::toolchain::pnpm_unapproved_builds(&js.workspace_root);
+            if matches!(
+                outcome,
+                crate::toolchain::InstallOutcome::InstalledIgnoredBuilds
+            ) || !unapproved.is_empty()
+            {
+                if checked_pnpm_roots.insert(js.workspace_root.clone()) {
+                    let mut resolved = false;
+                    if let Some(confirm) = &opts.confirm {
+                        let names = if unapproved.is_empty() {
+                            String::new()
+                        } else {
+                            format!(" ({})", unapproved.join(", "))
+                        };
+                        let prompt = format!(
+                            "pnpm dependency build scripts are unapproved{names} in {} — \
+                             run `pnpm approve-builds` now?",
+                            js.workspace_root.display()
+                        );
+                        if confirm(&prompt) {
+                            resolved = ctx.run_pnpm_approve_builds(&js.workspace_root)
+                                && crate::toolchain::pnpm_unapproved_builds(&js.workspace_root)
+                                    .is_empty();
+                        }
+                    }
+                    if !resolved {
+                        results.push(pnpm_unapproved_builds_result(
+                            dir,
+                            &js.workspace_root,
+                            &unapproved,
+                        ));
+                        broken_pnpm_roots.insert(js.workspace_root.clone());
+                    }
+                }
+                if broken_pnpm_roots.contains(&js.workspace_root) {
+                    // `pnpm exec` fails in this state — running the checks
+                    // would produce misleading SV007/SV010; SV018 explains.
+                    continue;
+                }
+            }
+            if let Some(diag) = js_deps_diagnostic(&ctx, &outcome, js, &plan.location) {
                 results.push(FileResult {
                     path: plan.rel.clone(),
                     diagnostics: vec![diag],
                 });
                 // Running tools without deps would produce misleading
                 // SV007/SV010 failures.
+                continue;
+            }
+        }
+        if plan.service_dir.join("mix.exs").is_file() {
+            if let Some(sink) = &opts.progress {
+                if !opts.no_install && !crate::toolchain::mix_deps_present(&plan.service_dir) {
+                    sink.notice(&format!(
+                        "installing mix dependencies in {}",
+                        plan.service_dir.display()
+                    ));
+                }
+            }
+            let outcome = ctx.ensure_mix_deps(&plan.service_dir);
+            if let Some(diag) =
+                mix_deps_diagnostic(&ctx, &outcome, &plan.service_dir, &plan.location)
+            {
+                results.push(FileResult {
+                    path: plan.rel.clone(),
+                    diagnostics: vec![diag],
+                });
                 continue;
             }
         }
@@ -532,6 +615,45 @@ pub fn validate_service_checks(dir: &Path, opts: &ServiceCheckOptions) -> Servic
             file_results: results,
             timings: Vec::new(),
         };
+    }
+
+    // Start devenv-managed services (postgres, …) for the duration of the
+    // checks — on a fresh clone the test suites would otherwise fail to reach
+    // their backing services. Stopped again (guard drop) only if dg started
+    // them.
+    let mut devenv_guard = None;
+    if !opts.no_install && runnable.iter().any(|p| p.test_framework.is_some()) {
+        if let Some(service_names) = crate::devenv::declared_services(dir) {
+            if crate::toolchain::binary_on_path("devenv", ctx.path()) {
+                use crate::devenv::StartOutcome;
+                match crate::devenv::start_services(
+                    dir,
+                    ctx.path(),
+                    &service_names,
+                    opts.progress.as_deref(),
+                ) {
+                    StartOutcome::Started(guard) => devenv_guard = Some(guard),
+                    StartOutcome::AlreadyRunning => {}
+                    StartOutcome::Failed { output_tail } => {
+                        results.push(FileResult {
+                            path: "devenv.nix".into(),
+                            diagnostics: vec![Diagnostic {
+                                severity: Severity::Warning,
+                                code: "SV019".into(),
+                                message: "devenv services could not be started — dependent \
+                                          tests may fail"
+                                    .into(),
+                                location: "devenv.nix".into(),
+                                hint: Some(format!(
+                                    "`devenv up -d` failed:\n        {output_tail}\n        \
+                                     start services manually with `devenv up -d`"
+                                )),
+                            }],
+                        });
+                    }
+                }
+            }
+        }
     }
 
     let check_count: usize = runnable
@@ -560,6 +682,10 @@ pub fn validate_service_checks(dir: &Path, opts: &ServiceCheckOptions) -> Servic
     if let Some(sink) = &opts.progress {
         sink.end();
     }
+
+    // Stop services dg started before assembling results, so `devenv down`
+    // time is not attributed to any check.
+    drop(devenv_guard);
 
     let mut timings = Vec::new();
     for (frs, ts) in per_service {
@@ -677,10 +803,46 @@ fn run_service_plan(
     (out, timings)
 }
 
-/// Ensure JS deps are installed; return an SV014 diagnostic when they are
+/// SV018: pnpm installed dependencies but left build scripts unapproved.
+fn pnpm_unapproved_builds_result(
+    dir: &Path,
+    workspace_root: &Path,
+    unapproved: &[String],
+) -> FileResult {
+    let rel = workspace_root
+        .strip_prefix(dir)
+        .unwrap_or(Path::new(""))
+        .join("pnpm-workspace.yaml");
+    let rel = rel.to_string_lossy().replace('\\', "/");
+    let names = if unapproved.is_empty() {
+        String::new()
+    } else {
+        format!(" for {}", unapproved.join(", "))
+    };
+    FileResult {
+        path: rel.clone(),
+        diagnostics: vec![Diagnostic {
+            severity: Severity::Warning,
+            code: "SV018".into(),
+            message: format!("pnpm dependency build scripts are unapproved{names}"),
+            location: rel,
+            hint: Some(format!(
+                "pnpm refuses to run commands until each build script is approved or \
+                 denied, so this workspace's lint/test checks were skipped — run \
+                 `pnpm approve-builds` in {} (or set each allowBuilds entry to \
+                 true/false in pnpm-workspace.yaml), or rerun `dg validate` in a \
+                 terminal to approve interactively",
+                workspace_root.display()
+            )),
+        }],
+    }
+}
+
+/// Map a JS deps install outcome to an SV014 diagnostic when dependencies are
 /// missing and could not be installed.
-fn ensure_js_deps_diagnostic(
-    ctx: &mut crate::toolchain::ToolchainContext,
+fn js_deps_diagnostic(
+    ctx: &crate::toolchain::ToolchainContext,
+    outcome: &crate::toolchain::InstallOutcome,
     js: &crate::toolchain::JsToolchain,
     location: &str,
 ) -> Option<Diagnostic> {
@@ -694,10 +856,19 @@ fn ensure_js_deps_diagnostic(
         .join(" ");
     let root = js.workspace_root.display();
 
-    let hint = match ctx.ensure_js_deps(js) {
-        InstallOutcome::AlreadyInstalled | InstallOutcome::Installed => return None,
+    let hint = match outcome {
+        InstallOutcome::AlreadyInstalled
+        | InstallOutcome::Installed
+        | InstallOutcome::InstalledIgnoredBuilds => return None,
         InstallOutcome::SkippedNoInstall => {
             format!("node_modules missing in {root}; rerun without --no-install or run `{install_cmd}` there")
+        }
+        InstallOutcome::SkippedNeedsApproval => {
+            format!(
+                "`{install_cmd}` may execute dependency install scripts, so dg only runs it \
+                 after interactive confirmation — rerun `dg validate` in a terminal and \
+                 approve it, or run `{install_cmd}` in {root} yourself"
+            )
         }
         InstallOutcome::SkippedNoPm { pm_binary } => {
             let mut hint = format!(
@@ -724,6 +895,63 @@ fn ensure_js_deps_diagnostic(
         severity: Severity::Warning,
         code: "SV014".into(),
         message: format!("dependencies not installed for {location} ({pm})"),
+        location: location.to_string(),
+        hint: Some(hint),
+    })
+}
+
+/// Map a mix deps install outcome to an SV014 diagnostic when dependencies
+/// are missing and could not be fetched.
+fn mix_deps_diagnostic(
+    ctx: &crate::toolchain::ToolchainContext,
+    outcome: &crate::toolchain::InstallOutcome,
+    service_dir: &Path,
+    location: &str,
+) -> Option<Diagnostic> {
+    use crate::toolchain::InstallOutcome;
+
+    let root = service_dir.display();
+    let hint = match outcome {
+        InstallOutcome::AlreadyInstalled
+        | InstallOutcome::Installed
+        | InstallOutcome::InstalledIgnoredBuilds => return None,
+        InstallOutcome::SkippedNoInstall => {
+            format!(
+                "deps/ missing in {root}; rerun without --no-install or run `mix deps.get` there"
+            )
+        }
+        // `mix deps.get` only fetches (no dep code runs) — never gated.
+        InstallOutcome::SkippedNeedsApproval => {
+            format!("run `mix deps.get` in {root}")
+        }
+        InstallOutcome::SkippedNoPm { pm_binary } => {
+            let mut hint = format!(
+                "`{pm_binary}` is not on PATH; install Elixir and run `mix deps.get` in {root}"
+            );
+            if let Some(env_hint) = ctx.env_hint() {
+                hint.push_str("\n        ");
+                hint.push_str(&env_hint);
+            }
+            hint
+        }
+        InstallOutcome::Failed {
+            exit_code,
+            output_tail,
+        } => {
+            let code = exit_code
+                .map(|c| format!(" (exit code {c})"))
+                .unwrap_or_default();
+            format!(
+                "`mix deps.get` failed{code} in {root}:\n        {output_tail}\n        \
+                 if Hex is not installed, run `mix local.hex --force` first"
+            )
+        }
+    };
+
+    Some(Diagnostic {
+        severity: Severity::Warning,
+        code: "SV014".into(),
+        message: format!("dependencies not installed for {location} (mix)"),
         location: location.to_string(),
         hint: Some(hint),
     })

--- a/crates/md-db/src/validation/document.rs
+++ b/crates/md-db/src/validation/document.rs
@@ -481,6 +481,14 @@ fn check_undefined_keys(
     // unknown. Everything else is schema-defined.
     const BUILTINS: &[&str] = &["type", "allow_diagram_cycles"];
 
+    // Keys from removed dg features. Checked only after the schema lookups so
+    // a project that defines its own field with the same name is unaffected.
+    const DEPRECATED_KEYS: &[(&str, &str)] = &[(
+        "code_paths",
+        "code_paths was removed — delete this key and reference the doc ID from \
+         source code comments instead (code refs are scanned automatically; see `dg refs`)",
+    )];
+
     for key in fm.keys() {
         // Check type-specific fields
         if type_def.fields.iter().any(|f| f.name == *key) {
@@ -492,6 +500,19 @@ fn check_undefined_keys(
         }
         // Check builtins
         if BUILTINS.contains(&key.as_str()) {
+            continue;
+        }
+        if let Some((_, hint)) = DEPRECATED_KEYS.iter().find(|(k, _)| k == key) {
+            diags.push(Diagnostic {
+                severity: Severity::Error,
+                code: "F023".into(),
+                message: format!(
+                    "deprecated frontmatter key \"{key}\" for type \"{}\"",
+                    type_def.name
+                ),
+                location: format!("frontmatter.{key}"),
+                hint: Some((*hint).to_string()),
+            });
             continue;
         }
         diags.push(Diagnostic {

--- a/crates/md-db/src/validation/mod.rs
+++ b/crates/md-db/src/validation/mod.rs
@@ -1807,6 +1807,65 @@ type "doc" {
     }
 
     #[test]
+    fn code_paths_key_is_deprecated_error() {
+        let schema = Schema::from_str(
+            r#"
+type "doc" {
+    field "title" type="string"
+}
+"#,
+        )
+        .unwrap();
+        let doc = Document::from_str(
+            "---\ntype: doc\ntitle: T\ncode_paths:\n  - src/main.rs\n---\n\n# T\n",
+        )
+        .unwrap();
+        let result = validate_document(&doc, &schema, &HashSet::new(), &HashSet::new(), None);
+        let f023 = result
+            .diagnostics
+            .iter()
+            .find(|d| d.code == "F023")
+            .expect("code_paths must produce F023");
+        assert_eq!(f023.severity, Severity::Error);
+        assert_eq!(f023.location, "frontmatter.code_paths");
+        assert!(
+            !result
+                .diagnostics
+                .iter()
+                .any(|d| d.code == "F020" && d.location == "frontmatter.code_paths"),
+            "code_paths must not also be F020: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
+    fn schema_defined_code_paths_field_is_not_deprecated() {
+        let schema = Schema::from_str(
+            r#"
+type "doc" {
+    field "title" type="string"
+    field "code_paths" type="string[]"
+}
+"#,
+        )
+        .unwrap();
+        let doc = Document::from_str(
+            "---\ntype: doc\ntitle: T\ncode_paths:\n  - src/main.rs\n---\n\n# T\n",
+        )
+        .unwrap();
+        let result = validate_document(&doc, &schema, &HashSet::new(), &HashSet::new(), None);
+        assert!(
+            !result
+                .diagnostics
+                .iter()
+                .any(|d| (d.code == "F023" || d.code == "F020")
+                    && d.location == "frontmatter.code_paths"),
+            "schema-defined code_paths must be accepted: {:?}",
+            result.diagnostics
+        );
+    }
+
+    #[test]
     #[cfg(feature = "diagrams")]
     fn nested_section_diagram_validated_once() {
         // Parent section content includes child sections, so without dedup the

--- a/devenv.nix
+++ b/devenv.nix
@@ -11,7 +11,19 @@ let
     # Claude Code may run outside the devenv shell: bootstrap PATH from the
     # devenv profile so cargo/rustc/bun are found either way.
     export PATH="$ROOT/.devenv/profile/bin:$PATH"
-    if command -v sccache >/dev/null; then export RUSTC_WRAPPER=sccache; fi
+    if command -v sccache >/dev/null; then
+      # A long-running sccache server keeps the env it was started with; a
+      # stale one can no longer find clang via xcrun and fails every C build
+      # script (ring/openssl-sys/libz-sys). Probe a real compile through
+      # sccache and restart the server with this hook's env if it fails.
+      probe() { echo 'int main(void){return 0;}' > "$1/probe.c" && sccache cc -c "$1/probe.c" -o "$1/probe.o" >/dev/null 2>&1; }
+      P=$(mktemp -d)
+      if ! probe "$P"; then
+        sccache --stop-server >/dev/null 2>&1 || true
+      fi
+      if probe "$P"; then export RUSTC_WRAPPER=sccache; fi
+      rm -rf "$P"
+    fi
     D=$(mktemp -d)
     trap 'rm -rf "$D"' EXIT
 


### PR DESCRIPTION
## What

`dg validate` on a fresh clone of a real-world monorepo (pnpm 11 workspace + Elixir services + OpenTofu) surfaced several gaps. This PR makes service checks work end-to-end unattended where safe, and interactively where dependency scripts could run.

### pnpm 11 unapproved build scripts (SV018, new)
pnpm 11 (`strictDepBuilds` default) writes node_modules fully **before** failing with `ERR_PNPM_IGNORED_BUILDS`, and also gates `pnpm exec` on that state. Previously this produced a bogus SV014 per app and skipped checks with a misleading hint.
- Install outcome `InstalledIgnoredBuilds`: deps are complete and usable.
- Interactive TTY: dg offers to run pnpm's own `pnpm approve-builds` picker — the user decides, dg never approves build scripts itself.
- Non-interactive: one SV018 warning per workspace (rerun-stable via unresolved `allowBuilds` placeholders in pnpm-workspace.yaml) and that workspace's checks are skipped instead of failing confusingly.

### Safe-install policy
npm/yarn installs execute dependency lifecycle scripts → now gated behind an interactive `[y/N]` prompt (skipped with an explanatory SV014 hint when no TTY). pnpm/bun block untrusted scripts themselves and `mix deps.get` only fetches, so those stay fully automatic.

### mix deps auto-install
`mix deps.get` (devenv-shell-wrapped when mix is only in the dev shell) runs before checks when `deps/` is missing; mix-flavored SV014 on failure.

### devenv services lifecycle (SV019, new)
When root `devenv.nix` declares `services.*` and tests will run: `devenv up -d` + `devenv processes wait` before checks, `devenv down` afterwards — only if dg started them. Already-running services are left alone. Start failure emits SV019 and checks proceed. Disabled by `--no-install`.

### Workspace-aware dependabot (SV012)
The old logic collapsed every npm hit to `/` whenever pnpm-workspace.yaml existed, hiding member dirs **and** wrongly dropping standalone npm dirs with their own lockfile. Now:
- SV012 enumerates all uncovered npm dirs (members and standalone).
- A root npm entry counts as covering workspace members (pnpm-workspace.yaml `packages` + package.json `workspaces`, incl. `!` negations).
- `dg init --dependabot` still generates only the root entry for members.

### code_paths → F023 error
The removed `code_paths` feature (superseded by code refs) now gets a deprecation **error** F023 instead of the generic F020 warning. A project defining its own `code_paths` schema field is unaffected.

### Stop-hook hardening
Probe sccache with a real compile and restart a stale server whose environment can no longer find clang (broke every C build script).

## Testing
- ~15 new unit tests (stub-binary pattern for pnpm/npm/mix/devenv flows, dependabot workspace scenarios incl. negated globs and generate/uncovered round-trip, F023).
- Full workspace suite + clippy clean.
- Verified end-to-end on a real monorepo: postgres auto-starts so ExUnit suites pass, mix deps auto-install, SV018/SV012/F023 fire as designed, services stopped afterwards.

## Out of scope (follow-ups)
- bun workspaces same treatment as npm in dependabot detection
- per-service devenv.nix service start
- `dg hooks` lint path still bypasses ToolchainContext